### PR TITLE
refactor: Delete `SparseLookupMatrix`

### DIFF
--- a/EngineeringOverview.md
+++ b/EngineeringOverview.md
@@ -62,9 +62,7 @@ $v_{E_i}$ is provided by sumcheck in step 2. $E_i(r_z)$ is provided by an oracle
 
 ### 1. Prover commitments
 
-`SparseLookupMatrix` is created from a `C` sized vector of non-zero indices along each dimension.
-
-We convert the `SparseLookupMatrix` to a `DensifiedRepresentation` which handles the construction of:
+We convert a `C` sized vector of lookup indices into a `DensifiedRepresentation` which handles the construction of:
 
 -   $`\text{dim}_i \ \forall i=1,...,C`$
 -   $`E_i \ \forall i=1,...,C`$

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Lookup Arguments via Sum-check and Sparse polynomial commitments, including for 
 ## Current usage
 
 ```rust
-  let lookup_matrix = SparseLookupMatrix::new(nz, log_M);
-  let mut dense: DensifiedRepresentation<F, C> = DensifiedRepresentation::from(&lookup_matrix);
+  let mut dense: DensifiedRepresentation<F, C> = DensifiedRepresentation::from(&nz, log_M);
   let commitment = dense.commit::<G>(&gens);
 
   let proof =

--- a/src/benches/bench.rs
+++ b/src/benches/bench.rs
@@ -1,10 +1,7 @@
 use crate::lasso::surge::SparsePolyCommitmentGens;
 use crate::subtables::and::AndSubtableStrategy;
 use crate::{
-  lasso::{
-    densified::DensifiedRepresentation,
-    surge::{SparseLookupMatrix, SparsePolynomialEvaluationProof},
-  },
+  lasso::{densified::DensifiedRepresentation, surge::SparsePolynomialEvaluationProof},
   utils::random::RandomTape,
 };
 use ark_curve25519::{EdwardsProjective, Fr};
@@ -52,10 +49,10 @@ macro_rules! single_pass_lasso {
       let r: Vec<F> = gen_random_point::<F>(log_s);
 
       let nz = gen_indices::<C>(S, M);
-      let lookup_matrix = SparseLookupMatrix::new(nz.clone(), log_m);
 
       // Prove
-      let mut dense: DensifiedRepresentation<F, C> = DensifiedRepresentation::from(&lookup_matrix);
+      let mut dense: DensifiedRepresentation<F, C> =
+        DensifiedRepresentation::from_lookup_indices(&nz, log_m);
       let gens = SparsePolyCommitmentGens::<G>::new(b"gens_sparse_poly", C, S, C, log_m);
       let _commitment = dense.commit::<$group>(&gens);
       let mut random_tape = RandomTape::new(b"proof");

--- a/src/e2e_test.rs
+++ b/src/e2e_test.rs
@@ -4,7 +4,7 @@ use merlin::Transcript;
 use crate::{
   lasso::{
     densified::DensifiedRepresentation,
-    surge::{SparseLookupMatrix, SparsePolyCommitmentGens, SparsePolynomialEvaluationProof},
+    surge::{SparsePolyCommitmentGens, SparsePolynomialEvaluationProof},
   },
   subtables::{
     and::AndSubtableStrategy, lt::LTSubtableStrategy, range_check::RangeCheckSubtableStrategy,
@@ -32,9 +32,8 @@ macro_rules! e2e_test {
       // generate sparse polynomial
       let nz: Vec<[usize; C]> = gen_indices($sparsity, M);
 
-      let lookup_matrix = SparseLookupMatrix::new(nz, log_M);
-
-      let mut dense: DensifiedRepresentation<$F, C> = DensifiedRepresentation::from(&lookup_matrix);
+      let mut dense: DensifiedRepresentation<$F, C> =
+        DensifiedRepresentation::from_lookup_indices(&nz, log_M);
       let gens =
         SparsePolyCommitmentGens::<$G>::new(b"gens_sparse_poly", C, $sparsity, NUM_MEMORIES, log_M);
       let commitment = dense.commit::<$G>(&gens);

--- a/src/lasso/surge.rs
+++ b/src/lasso/surge.rs
@@ -81,27 +81,6 @@ impl<G: CurveGroup> AppendToTranscript<G> for SparsePolynomialCommitment<G> {
 }
 
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct SparseLookupMatrix<const C: usize> {
-  pub nz: Vec<[usize; C]>, // non-zero indices nz_1(i), ..., nz_c(i)
-  pub s: usize,            // sparsity
-  pub log_m: usize,
-  pub m: usize,
-}
-
-impl<const C: usize> SparseLookupMatrix<C> {
-  pub fn new(nonzero_indices: Vec<[usize; C]>, log_m: usize) -> Self {
-    let s = nonzero_indices.len().next_power_of_two();
-
-    SparseLookupMatrix {
-      nz: nonzero_indices,
-      s,
-      log_m,
-      m: log_m.pow2(),
-    }
-  }
-}
-
-#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
 struct PrimarySumcheck<G: CurveGroup, const ALPHA: usize> {
   proof: SumcheckInstanceProof<G::ScalarField>,
   claimed_evaluation: G::ScalarField,


### PR DESCRIPTION
`SparseLookupMatrix` doesn't do much anymore, fold it into `DensifiedRepresentation::from_lookup_indices` (previously `DensifiedRepresentation::from`)