### PR TITLE
JALR Instruction 

### DIFF
--- a/src/jolt/instruction/jalr.rs
+++ b/src/jolt/instruction/jalr.rs
@@ -56,7 +56,7 @@ impl JoltInstruction for JALRInstruction {
   }
 
   fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
-    add_and_chunk_operands(self.0, self.1+4, C, log_M)
+    add_and_chunk_operands(self.0, self.1.overflowing_add(4).0, C, log_M)
   }
 }
 
@@ -78,7 +78,7 @@ mod test {
 
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
-      let z = x.overflowing_add(y+4).0;
+      let z = x.overflowing_add(y.overflowing_add(4).0).0;
       jolt_instruction_test!(JALRInstruction(x, y), (z - z%2).into());
     }
   }

--- a/src/jolt/instruction/jalr.rs
+++ b/src/jolt/instruction/jalr.rs
@@ -1,0 +1,85 @@
+// use core::slice::SlicePattern;
+use ark_ff::PrimeField;
+use ark_std::log2;
+
+use super::JoltInstruction;
+use crate::jolt::subtable::{
+  identity::IdentitySubtable, 
+  truncate_overflow::TruncateOverflowSubtable, 
+  zero_lsb::ZeroLSBSubtable, 
+  LassoSubtable,
+};
+use crate::utils::instruction_utils::{
+  add_and_chunk_operands, chunk_and_concatenate_operands, concatenate_lookups,
+};
+
+#[derive(Copy, Clone, Default, Debug)]
+pub struct JALRInstruction(pub u64, pub u64);
+
+impl JoltInstruction for JALRInstruction {
+  fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
+    // C from IDEN, C from TruncateOverflow, C from ZeroLSB
+    assert!(vals.len() == 3 * C);
+
+    const WORD_SIZE: usize = 64;
+    let msb_chunk_index = C - (WORD_SIZE / log2(M) as usize) - 1;
+
+    let mut vals_by_subtable = vals.chunks_exact(C);
+    let identity = vals_by_subtable.next().unwrap();
+    let truncate_overflow = vals_by_subtable.next().unwrap();
+    let zero_lsb = vals_by_subtable.next().unwrap();
+
+    // The output is the LOWER9(most significant chunk) || IDEN of other chunks
+    concatenate_lookups(
+      [
+        &truncate_overflow[0..=msb_chunk_index],
+        &identity[msb_chunk_index + 1..C-1],
+        &zero_lsb[C-1..C],
+      ]
+      .concat()
+      .as_slice(),
+      C,
+      log2(M) as usize,
+    )
+  }
+
+  fn g_poly_degree(&self, _: usize) -> usize {
+    1
+  }
+
+  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+    vec![
+      Box::new(IdentitySubtable::new()),
+      Box::new(TruncateOverflowSubtable::new()),
+      Box::new(ZeroLSBSubtable::new()),
+    ]
+  }
+
+  fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
+    add_and_chunk_operands(self.0, self.1+4, C, log_M)
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use ark_curve25519::Fr;
+  use ark_std::test_rng;
+  use rand_chacha::rand_core::RngCore;
+
+  use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
+
+  use super::JALRInstruction;
+
+  #[test]
+  fn jalr_instruction_e2e() {
+    let mut rng = test_rng();
+    const C: usize = 8;
+    const M: usize = 1 << 16;
+
+    for _ in 0..256 {
+      let (x, y) = (rng.next_u64(), rng.next_u64());
+      let z = x.overflowing_add(y+4).0;
+      jolt_instruction_test!(JALRInstruction(x, y), (z - z%2).into());
+    }
+  }
+}

--- a/src/jolt/instruction/mod.rs
+++ b/src/jolt/instruction/mod.rs
@@ -29,6 +29,7 @@ pub mod slt;
 pub mod sltu;
 pub mod xor;
 pub mod add; 
+pub mod jalr; 
 
 #[cfg(test)]
 pub mod test;

--- a/src/jolt/subtable/mod.rs
+++ b/src/jolt/subtable/mod.rs
@@ -24,6 +24,7 @@ pub mod or;
 pub mod xor;
 pub mod identity;
 pub mod truncate_overflow;
+pub mod zero_lsb;
 
 #[cfg(test)]
 pub mod test;

--- a/src/jolt/subtable/zero_lsb.rs
+++ b/src/jolt/subtable/zero_lsb.rs
@@ -1,0 +1,46 @@
+use ark_ff::PrimeField;
+use ark_std::log2;
+use std::marker::PhantomData;
+
+use super::LassoSubtable;
+
+#[derive(Default)]
+pub struct ZeroLSBSubtable<F: PrimeField> {
+  _field: PhantomData<F>,
+}
+
+impl<F: PrimeField> ZeroLSBSubtable<F> {
+  pub fn new() -> Self {
+    Self {
+      _field: PhantomData,
+    }
+  }
+}
+
+impl<F: PrimeField> LassoSubtable<F> for ZeroLSBSubtable<F> {
+  fn materialize(&self, M: usize) -> Vec<F> {
+    // always set LSB to 0
+    (0..M).map(|i| F::from((i-(i%2)) as u64)).collect()
+  }
+
+  fn evaluate_mle(&self, point: &[F]) -> F {
+    let mut result = F::zero();
+    // skip LSB
+    for i in 1..point.len() {
+      result += F::from(1u64 << i) * point[point.len() - 1 - i];
+    }
+    result
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use ark_curve25519::Fr;
+
+  use crate::{
+    jolt::subtable::{zero_lsb::ZeroLSBSubtable, LassoSubtable},
+    subtable_materialize_mle_parity_test,
+  };
+
+  subtable_materialize_mle_parity_test!(zero_lsb_materialize_mle_parity, ZeroLSBSubtable<Fr>, Fr, 256);
+}


### PR DESCRIPTION
With the zero_lsb subtable. Given x, y as input, the table entry is the lower 64 bits of z = x+y+4 with the LSB of z set to 0. (In the full system, the R1CS will handle the calculation and send just the 65-bit z to the lookup.)