### PR TITLE
[JOLT-45] Make SLLInstruction generic-ish over C

### DIFF
--- a/src/jolt/instruction/add.rs
+++ b/src/jolt/instruction/add.rs
@@ -42,7 +42,7 @@ impl JoltInstruction for ADDInstruction {
     1
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![
       Box::new(IdentitySubtable::new()),
       Box::new(TruncateOverflowSubtable::new()),

--- a/src/jolt/instruction/and.rs
+++ b/src/jolt/instruction/and.rs
@@ -17,7 +17,7 @@ impl JoltInstruction for ANDInstruction {
     1
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![Box::new(AndSubtable::new())]
   }
 

--- a/src/jolt/instruction/beq.rs
+++ b/src/jolt/instruction/beq.rs
@@ -18,7 +18,7 @@ impl JoltInstruction for BNEInstruction {
     C
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![Box::new(EqSubtable::new())]
   }
 

--- a/src/jolt/instruction/bge.rs
+++ b/src/jolt/instruction/bge.rs
@@ -22,7 +22,7 @@ impl JoltInstruction for BGEInstruction {
     C
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![
       Box::new(GtMSBSubtable::new()),
       Box::new(EqMSBSubtable::new()),

--- a/src/jolt/instruction/bgeu.rs
+++ b/src/jolt/instruction/bgeu.rs
@@ -19,7 +19,7 @@ impl JoltInstruction for BGEUInstruction {
     C
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![Box::new(LtuSubtable::new()), Box::new(EqSubtable::new())]
   }
 

--- a/src/jolt/instruction/bne.rs
+++ b/src/jolt/instruction/bne.rs
@@ -18,7 +18,7 @@ impl JoltInstruction for BNEInstruction {
     C
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![Box::new(EqSubtable::new())]
   }
 

--- a/src/jolt/instruction/jal.rs
+++ b/src/jolt/instruction/jal.rs
@@ -42,7 +42,7 @@ impl JoltInstruction for JALInstruction {
     1
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![
       Box::new(IdentitySubtable::new()),
       Box::new(TruncateOverflowSubtable::new()),

--- a/src/jolt/instruction/jalr.rs
+++ b/src/jolt/instruction/jalr.rs
@@ -44,7 +44,7 @@ impl JoltInstruction for JALRInstruction {
     1
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![
       Box::new(IdentitySubtable::new()),
       Box::new(TruncateOverflowSubtable::new()),

--- a/src/jolt/instruction/mod.rs
+++ b/src/jolt/instruction/mod.rs
@@ -7,7 +7,7 @@ use crate::jolt::{subtable::LassoSubtable, vm::test_vm::TestInstructionSet};
 pub trait JoltInstruction {
   fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F;
   fn g_poly_degree(&self, C: usize) -> usize;
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>>;
+  fn subtables<F: PrimeField>(&self, C: usize) -> Vec<Box<dyn LassoSubtable<F>>>;
   fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize>;
 }
 

--- a/src/jolt/instruction/or.rs
+++ b/src/jolt/instruction/or.rs
@@ -17,7 +17,7 @@ impl JoltInstruction for ORInstruction {
     1
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![Box::new(OrSubtable::new())]
   }
 

--- a/src/jolt/instruction/sll.rs
+++ b/src/jolt/instruction/sll.rs
@@ -13,9 +13,8 @@ pub struct SLLInstruction(pub u64, pub u64);
 
 impl JoltInstruction for SLLInstruction {
   fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
-    // TODO(JOLT-45): make this more robust
-    assert!(C <= 6);
-    assert!(vals.len() == 6 * C);
+    assert!(C <= 10);
+    assert!(vals.len() == C * C);
 
     let mut subtable_vals = vals.chunks_exact(C);
     let mut vals_filtered: Vec<F> = Vec::with_capacity(C);
@@ -31,15 +30,22 @@ impl JoltInstruction for SLLInstruction {
     1
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
-    vec![
-      Box::new(SllSubtable::<F, 5>::new()),
-      Box::new(SllSubtable::<F, 4>::new()),
-      Box::new(SllSubtable::<F, 3>::new()),
-      Box::new(SllSubtable::<F, 2>::new()),
-      Box::new(SllSubtable::<F, 1>::new()),
+  fn subtables<F: PrimeField>(&self, C: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
+    let mut subtables: Vec<Box<dyn LassoSubtable<F>>> = vec![
       Box::new(SllSubtable::<F, 0>::new()),
-    ]
+      Box::new(SllSubtable::<F, 1>::new()),
+      Box::new(SllSubtable::<F, 2>::new()),
+      Box::new(SllSubtable::<F, 3>::new()),
+      Box::new(SllSubtable::<F, 4>::new()),
+      Box::new(SllSubtable::<F, 5>::new()),
+      Box::new(SllSubtable::<F, 6>::new()),
+      Box::new(SllSubtable::<F, 7>::new()),
+      Box::new(SllSubtable::<F, 8>::new()),
+      Box::new(SllSubtable::<F, 9>::new()),
+    ];
+    subtables.truncate(C);
+    subtables.reverse();
+    subtables
   }
 
   fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {

--- a/src/jolt/instruction/slt.rs
+++ b/src/jolt/instruction/slt.rs
@@ -41,7 +41,7 @@ impl JoltInstruction for SLTInstruction {
     C
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![
       Box::new(GtMSBSubtable::new()),
       Box::new(EqMSBSubtable::new()),

--- a/src/jolt/instruction/sltu.rs
+++ b/src/jolt/instruction/sltu.rs
@@ -25,7 +25,7 @@ impl JoltInstruction for SLTUInstruction {
     C
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![Box::new(LtuSubtable::new()), Box::new(EqSubtable::new())]
   }
 

--- a/src/jolt/instruction/sub.rs
+++ b/src/jolt/instruction/sub.rs
@@ -42,7 +42,7 @@ impl JoltInstruction for SUBInstruction {
     1
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![
       Box::new(IdentitySubtable::new()),
       Box::new(TruncateOverflowSubtable::new()),

--- a/src/jolt/instruction/test.rs
+++ b/src/jolt/instruction/test.rs
@@ -2,14 +2,14 @@
 macro_rules! jolt_instruction_test {
   ($instr:expr, $expected_value:expr) => {
     let materialized_subtables: Vec<_> = $instr
-      .subtables::<Fr>()
+      .subtables::<Fr>(C)
       .iter()
       .map(|subtable| subtable.materialize(M))
       .collect();
 
     let subtable_lookup_indices = $instr.to_indices(C, ark_std::log2(M) as usize);
 
-    let mut subtable_values: Vec<Fr> = Vec::with_capacity(C * $instr.subtables::<Fr>().len());
+    let mut subtable_values: Vec<Fr> = Vec::with_capacity(C * $instr.subtables::<Fr>(C).len());
     for subtable in materialized_subtables {
       for lookup_index in subtable_lookup_indices.iter() {
         subtable_values.push(subtable[*lookup_index]);

--- a/src/jolt/instruction/xor.rs
+++ b/src/jolt/instruction/xor.rs
@@ -17,7 +17,7 @@ impl JoltInstruction for XORInstruction {
     1
   }
 
-  fn subtables<F: PrimeField>(&self) -> Vec<Box<dyn LassoSubtable<F>>> {
+  fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
     vec![Box::new(XorSubtable::new())]
   }
 

--- a/src/jolt/vm/mod.rs
+++ b/src/jolt/vm/mod.rs
@@ -685,7 +685,7 @@ pub trait Jolt<F: PrimeField, G: CurveGroup<ScalarField = F>> {
 
   fn instruction_to_memory_indices(op: &Self::InstructionSet) -> Vec<usize> {
     let instruction_subtables: Vec<Self::Subtables> = op
-      .subtables::<F>()
+      .subtables::<F>(Self::C)
       .iter()
       .map(|subtable| Self::Subtables::from(subtable.subtable_id()))
       .collect();
@@ -791,7 +791,7 @@ pub trait Jolt<F: PrimeField, G: CurveGroup<ScalarField = F>> {
       .map(|instruction| {
         // TODO(sragss): Box<dyn SubtableTrait>.into() should work via additional functionality on the trait .
         let instruction_subtable_ids: Vec<usize> = instruction
-          .subtables::<F>()
+          .subtables::<F>(Self::C)
           .iter()
           .map(|subtable| Self::Subtables::from(subtable.subtable_id()).into())
           .collect();
@@ -814,7 +814,7 @@ pub trait Jolt<F: PrimeField, G: CurveGroup<ScalarField = F>> {
 
     for instruction in Self::InstructionSet::iter() {
       let instruction_subtables: Vec<Self::Subtables> = instruction
-        .subtables::<F>()
+        .subtables::<F>(Self::C)
         .iter()
         .map(|subtable| Self::Subtables::from(subtable.subtable_id()))
         .collect();

--- a/src/jolt/vm/test_vm.rs
+++ b/src/jolt/vm/test_vm.rs
@@ -136,7 +136,7 @@ mod tests {
   fn instruction_set_subtables() {
     let mut subtable_set: HashSet<_> = HashSet::new();
     for instruction in <TestJoltVM as Jolt<_, EdwardsProjective>>::InstructionSet::iter() {
-      for subtable in instruction.subtables::<Fr>() {
+      for subtable in instruction.subtables::<Fr>(<TestJoltVM as Jolt<_, EdwardsProjective>>::C) {
         // panics if subtable cannot be cast to enum variant
         let _ = <TestJoltVM as Jolt<_, EdwardsProjective>>::Subtables::from(subtable.subtable_id());
         subtable_set.insert(subtable.subtable_id());

--- a/src/lasso/surge_2.rs
+++ b/src/lasso/surge_2.rs
@@ -376,7 +376,7 @@ impl<G: CurveGroup, I: JoltInstruction + Default + std::marker::Sync> SurgeProof
 
     let num_ops: usize = ops.len();
     let log_num_ops: usize = num_ops.log_2();
-    let num_memories: usize = instruction.subtables::<G::ScalarField>().len() * C; // alpha // TODO(sragss): Could move to JoltInstruction trait
+    let num_memories: usize = instruction.subtables::<G::ScalarField>(C).len() * C; // alpha // TODO(sragss): Could move to JoltInstruction trait
     let memory_size: usize = M; // M
 
     let generators: SurgeCommitmentGens<G> = SurgeCommitmentGens::new(C, memory_size, num_ops, num_memories);
@@ -499,7 +499,7 @@ impl<G: CurveGroup, I: JoltInstruction + Default + std::marker::Sync> SurgeProof
     let memory_to_dimension_index = | memory_index: usize | { memory_index % self.C };
     let evaluate_memory_mle = | memory_index: usize, vals: &[G::ScalarField]| { 
         let subtable_index = memory_index / self.C;
-        instruction.subtables()[subtable_index].evaluate_mle(vals)
+        instruction.subtables(self.C)[subtable_index].evaluate_mle(vals)
       };
     
     self.memory_check.verify(
@@ -517,7 +517,7 @@ impl<G: CurveGroup, I: JoltInstruction + Default + std::marker::Sync> SurgeProof
   fn construct_polys(ops: &Vec<I>, C: usize, M: usize) -> SurgePolys<G::ScalarField> {
     let num_ops = ops.len().next_power_of_two();
     let instruction = I::default();
-    let num_unique_subtables = instruction.subtables::<G::ScalarField>().len();
+    let num_unique_subtables = instruction.subtables::<G::ScalarField>(C).len();
     let alpha = C * num_unique_subtables;
 
     let mut dim_i_usize: Vec<Vec<usize>> = vec![vec![0; num_ops]; C];
@@ -549,7 +549,7 @@ impl<G: CurveGroup, I: JoltInstruction + Default + std::marker::Sync> SurgeProof
 
     // Construct E
     let mut E_i_evals = Vec::with_capacity(alpha);
-    let materialized_subtables: Vec<Vec<G::ScalarField>> = instruction.subtables::<G::ScalarField>().iter().map(|subtable| subtable.materialize(M)).collect();
+    let materialized_subtables: Vec<Vec<G::ScalarField>> = instruction.subtables::<G::ScalarField>(C).iter().map(|subtable| subtable.materialize(M)).collect();
     for E_index in 0..alpha {
       let mut E_evals = Vec::with_capacity(num_ops);
       for op_index in 0..num_ops {


### PR DESCRIPTION
Requires threading C through the `subtables` method