### PR TITLE
Build jolt.circom via Cargo

### DIFF
--- a/jolt-core/build.rs
+++ b/jolt-core/build.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    build_circom();
+}
+
+fn build_circom() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("could not find CARGO_MANIFEST_DIR"); // Absolute path to jolt-core
+    let script_path = PathBuf::from(&manifest_dir).join("src/r1cs/scripts/compile_jolt.sh");
+    let circom_path = PathBuf::from(&manifest_dir).join("src/r1cs/circuits/jolt.circom");
+    let target_dir = env::var("OUT_DIR").expect("could not find OUT_DIR");
+    let out_dir = PathBuf::from(&target_dir).join("circom");
+
+    // Store in environment variable which binary can read
+    let out_dir_str = out_dir.to_str().expect("failed to convert path to string");
+    println!("cargo:rustc-env=CIRCUIT_DIR={out_dir_str}");
+
+    let status = Command::new(script_path)
+        .arg(&circom_path)
+        .arg(&out_dir)
+        .status()
+        .expect("failed to build circom");
+    assert!(status.success());
+}

--- a/jolt-core/src/r1cs/circuits/compile_jolt.sh
+++ b/jolt-core/src/r1cs/circuits/compile_jolt.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-cd src/r1cs/circuits
-mkdir -p jolt
-circom jolt.circom --r1cs --wasm --sym --c --output jolt
-cd -

--- a/jolt-core/src/r1cs/scripts/compile_jolt.sh
+++ b/jolt-core/src/r1cs/scripts/compile_jolt.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+CIRCUIT_DIR=$1
+OUT_DIR=$2
+
+mkdir -p $OUT_DIR
+circom ${CIRCUIT_DIR} --r1cs --wasm --sym --c --output ${OUT_DIR}


### PR DESCRIPTION
- Stores the compiled artifacts to `./target/<build type>/jolt-core-<post-fix>/out/circom/...`
- Stores this path to `CIRCUIT_DIR`
- `snark.rs` reads `CIRCUIT_DIR`