### PR TITLE
feat: add example programs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,12 @@ license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [workspace]
-members = ["jolt-core", "tracer"]
+members = [
+    "jolt-core",
+    "tracer",
+    "examples/fibonacci",
+    "examples/hash"
+]
 
 [profile.release]
 debug = true

--- a/examples/fibonacci/Cargo.toml
+++ b/examples/fibonacci/Cargo.toml
@@ -1,0 +1,12 @@
+cargo-features = ["per-package-target"]
+
+[package]
+name = "fibonacci"
+version = "0.1.0"
+edition = "2021"
+
+forced-target = "riscv32i-unknown-none-elf"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/fibonacci/build.rs
+++ b/examples/fibonacci/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bin=fibonacci=-Texamples/fibonacci/linker.ld");
+}

--- a/examples/fibonacci/linker.ld
+++ b/examples/fibonacci/linker.ld
@@ -1,0 +1,25 @@
+MEMORY {
+  program (rwx) : ORIGIN = 0x80000000, LENGTH = 2 * 1024 * 1024
+}
+
+SECTIONS {
+  .text.boot : {
+    *(.text.boot)
+  } > program
+
+  .text : {
+    *(.text)
+  } > program
+
+  .data : {
+    *(.data)
+  } > program
+
+  .bss : {
+    *(.bss)
+  } > program
+
+  . = ALIGN(8);
+  . = . + 4096;
+  _STACK_PTR = .;
+}

--- a/examples/fibonacci/src/entry.s
+++ b/examples/fibonacci/src/entry.s
@@ -1,0 +1,8 @@
+.global _start
+.extern _STACK_PTR
+
+.section .text.boot
+
+_start:	la sp, _STACK_PTR
+	jal main
+	j .

--- a/examples/fibonacci/src/main.rs
+++ b/examples/fibonacci/src/main.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use core::arch::global_asm;
+use core::panic::PanicInfo;
+
+global_asm!(include_str!("entry.s"));
+
+#[no_mangle]
+pub extern "C" fn main() {
+    fib(5);
+}
+
+fn fib(n: u32) -> u32 {
+    if n <= 1 {
+        1
+    } else {
+        fib(n-1) + fib(n-2)
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+   loop {}
+}

--- a/examples/hash/Cargo.toml
+++ b/examples/hash/Cargo.toml
@@ -1,0 +1,13 @@
+cargo-features = ["per-package-target"]
+
+[package]
+name = "hash"
+version = "0.1.0"
+edition = "2021"
+
+forced-target = "riscv32i-unknown-none-elf"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sha3 = { version = "0.10.8", default-features = false }

--- a/examples/hash/build.rs
+++ b/examples/hash/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bin=hash=-Texamples/hash/linker.ld");
+}

--- a/examples/hash/linker.ld
+++ b/examples/hash/linker.ld
@@ -1,0 +1,25 @@
+MEMORY {
+  program (rwx) : ORIGIN = 0x80000000, LENGTH = 2 * 1024 * 1024
+}
+
+SECTIONS {
+  .text.boot : {
+    *(.text.boot)
+  } > program
+
+  .text : {
+    *(.text)
+  } > program
+
+  .data : {
+    *(.data)
+  } > program
+
+  .bss : {
+    *(.bss)
+  } > program
+
+  . = ALIGN(8);
+  . = . + 4096;
+  _STACK_PTR = .;
+}

--- a/examples/hash/src/entry.s
+++ b/examples/hash/src/entry.s
@@ -1,0 +1,8 @@
+.global _start
+.extern _STACK_PTR
+
+.section .text.boot
+
+_start:	la sp, _STACK_PTR
+	jal main
+	j .

--- a/examples/hash/src/main.rs
+++ b/examples/hash/src/main.rs
@@ -1,0 +1,22 @@
+#![no_std]
+#![no_main]
+
+use core::arch::global_asm;
+use core::panic::PanicInfo;
+
+use sha3::{Keccak256, Digest};
+
+global_asm!(include_str!("entry.s"));
+
+#[no_mangle]
+pub extern "C" fn main() {
+    let mut hasher = Keccak256::new();
+    let inputs = [5u8; 32];
+    hasher.update(inputs);
+    let _result = hasher.finalize();
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+   loop {}
+}


### PR DESCRIPTION
Adds example programs for fibonacci and keccak hashing. To build either, run `cargo build --release -p hash` or `cargo build --release -p fibonacci`. The binary elf files should then be in `target/riscv32i-unknown-none-elf/release`.