### PR TITLE
feat: decode elf files

### DIFF
--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -17,5 +17,6 @@ edition="2021"
 
 [dependencies]
 fnv = "1.0.7"
-common = { path = "../common" }
 object = "0.32.1"
+
+common = { path = "../common" }

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -18,3 +18,4 @@ edition="2021"
 [dependencies]
 fnv = "1.0.7"
 common = { path = "../common" }
+object = "0.32.1"

--- a/tracer/src/decode.rs
+++ b/tracer/src/decode.rs
@@ -1,0 +1,18 @@
+use crate::emulator::cpu::{INSTRUCTIONS, Instruction};
+
+pub fn decode_raw(word: u32) -> Result<Instruction, ()> {
+	match decode_and_get_instruction_index(word) {
+		Ok(index) => Ok(INSTRUCTIONS[index].clone()),
+		Err(()) => Err(())
+	}
+}
+
+fn decode_and_get_instruction_index(word: u32) -> Result<usize, ()> {
+	for i in 0..INSTRUCTIONS.len() {
+		let inst = &INSTRUCTIONS[i];
+		if (word & inst.mask) == inst.data {
+			return Ok(i);
+		}
+	}
+	return Err(())
+}

--- a/tracer/src/lib.rs
+++ b/tracer/src/lib.rs
@@ -2,23 +2,23 @@
 
 use std::{path::PathBuf, fs::File, io::Read};
 
-use emulator::{default_terminal::DefaultTerminal, Emulator, cpu};
+use emulator::{default_terminal::DefaultTerminal, Emulator, cpu::{self, Xlen}};
 use common;
 
+use object::{Object, ObjectSection, SectionKind};
+
 mod trace;
+mod decode;
 mod emulator;
 
 pub use common::{TraceRow, Instruction, RegisterState, MemoryState};
 
+use crate::decode::decode_raw;
+
 pub fn trace(elf: PathBuf) -> Vec<TraceRow> {
     let term = DefaultTerminal::new();
     let mut emulator = Emulator::new(Box::new(term));
-
-    match common::constants::XLEN {
-        32 => emulator.update_xlen(cpu::Xlen::Bit32),
-        64 => emulator.update_xlen(cpu::Xlen::Bit64),
-        _ => panic!("Emulator only supports 32 / 64 bit registers.")
-    };
+    emulator.update_xlen(get_xlen());
 
     let mut elf_file = File::open(elf).unwrap();
 
@@ -47,4 +47,42 @@ pub fn trace(elf: PathBuf) -> Vec<TraceRow> {
     output.append(&mut rows);
 
     output
+}
+
+pub fn decode(elf: PathBuf) -> Vec<Instruction> {
+    let mut elf_file = File::open(elf).unwrap();
+    let mut elf_contents = Vec::new();
+    elf_file.read_to_end(&mut elf_contents).unwrap();
+
+    let obj = object::File::parse(&*elf_contents).unwrap();
+
+    let text_sections = obj
+        .sections()
+        .filter(|s| s.kind() == SectionKind::Text)
+        .collect::<Vec<_>>();
+
+    let mut instructions = Vec::new();
+    for section in text_sections {
+        let data = section.data().unwrap();
+
+        for (chunk, word) in data.chunks(4).enumerate() {
+            let word = u32::from_le_bytes(word.try_into().unwrap());
+            let address = chunk as u64 * 4 + section.address();
+            let inst = decode_raw(word).unwrap();
+            let trace = inst.trace.unwrap();
+
+            let inst = trace(&inst, &get_xlen(), word, address);
+            instructions.push(inst);
+        }
+    }
+
+    instructions
+}
+
+fn get_xlen() -> Xlen {
+    match common::constants::XLEN {
+        32 => cpu::Xlen::Bit32,
+        64 => cpu::Xlen::Bit64,
+        _ => panic!("Emulator only supports 32 / 64 bit registers.")
+    }
 }

--- a/tracer/src/main.rs
+++ b/tracer/src/main.rs
@@ -1,12 +1,11 @@
 extern crate tracer;
 
-use tracer::trace;
+use tracer::{trace, decode};
 
 pub fn main() {
     let rows = trace("../jolt-compiler/target/riscv32i-unknown-none-elf/release/program".into());
-    for row in &rows {
-        println!("{:?}\n", row);
-    }
+    println!("{:?}", rows);
 
-    println!("trace lenth: {}", rows.len());
+    let instructions = decode("./target/riscv32i-unknown-none-elf/release/fibonacci".into());
+    println!("{:?}", instructions);
 }

--- a/tracer/src/main.rs
+++ b/tracer/src/main.rs
@@ -3,7 +3,7 @@ extern crate tracer;
 use tracer::{trace, decode};
 
 pub fn main() {
-    let rows = trace("../jolt-compiler/target/riscv32i-unknown-none-elf/release/program".into());
+    let rows = trace("./target/riscv32i-unknown-none-elf/release/fibonacci".into());
     println!("{:?}", rows);
 
     let instructions = decode("./target/riscv32i-unknown-none-elf/release/fibonacci".into());


### PR DESCRIPTION
Adds a `decode` function which decodes an elf file and returns `Vec<common::Instruction>`. One important thing to note is that even though I think the instructions should be in order with no gaps, there is a chance the compiler doesn't do this (there is no requirement that the different text sections be laid out in order without gaps, but in my testing they seem to). I'd just go by the `address` of each instruction rather than the location in the vector. 

I'm happy to make some changes here to make understanding the different sections (rather than concatenating everything) easier. Alternatively we can check for consistency and panic if anything is not laid out nicely, and cross that bridge if it ever comes up.