### PR TITLE
Lookup output function

### DIFF
--- a/jolt-core/src/jolt/instruction/add.rs
+++ b/jolt-core/src/jolt/instruction/add.rs
@@ -73,6 +73,7 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u32(), rng.next_u32());
       jolt_instruction_test!(ADDInstruction(x as u64, y as u64), (x.overflowing_add(y)).0.into());
+      assert_eq!(ADDInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M), (x.overflowing_add(y)).0.into());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -45,6 +45,7 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
       jolt_instruction_test!(ANDInstruction(x, y), (x & y).into());
+      assert_eq!(ANDInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M), (x & y).into());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/beq.rs
+++ b/jolt-core/src/jolt/instruction/beq.rs
@@ -46,10 +46,12 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
       jolt_instruction_test!(BEQInstruction(x, y), (x == y).into());
+      assert_eq!(BEQInstruction(x, y).lookup_entry::<Fr>(C, M), (x == y).into());
     }
     for _ in 0..256 {
       let x = rng.next_u64();
       jolt_instruction_test!(BEQInstruction(x, x), Fr::one());
+      assert_eq!(BEQInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::one());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -58,10 +58,12 @@ mod test {
       let x = rng.next_u64() as i64;
       let y = rng.next_u64() as i64;
       jolt_instruction_test!(BGEInstruction(x, y), (x >= y).into());
+      assert_eq!(BGEInstruction(x, y).lookup_entry::<Fr>(C, M), (x >= y).into());
     }
     for _ in 0..256 {
       let x = rng.next_u64() as i64;
       jolt_instruction_test!(BGEInstruction(x, x), Fr::one());
+      assert_eq!(BGEInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::one());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -47,10 +47,12 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
       jolt_instruction_test!(BGEUInstruction(x, y), (x >= y).into());
+      assert_eq!(BGEUInstruction(x, y).lookup_entry::<Fr>(C, M), (x >= y).into());
     }
     for _ in 0..256 {
       let x = rng.next_u64();
       jolt_instruction_test!(BGEUInstruction(x, x), Fr::one());
+      assert_eq!(BGEUInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::one());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/blt.rs
+++ b/jolt-core/src/jolt/instruction/blt.rs
@@ -22,10 +22,12 @@ mod test {
       let x = rng.next_u64() as i64;
       let y = rng.next_u64() as i64;
       jolt_instruction_test!(BLTInstruction(x, y), (x < y).into());
+      assert_eq!(BLTInstruction(x, y).lookup_entry::<Fr>(C, M), (x < y).into());
     }
     for _ in 0..256 {
       let x = rng.next_u64() as i64;
       jolt_instruction_test!(BLTInstruction(x, x), Fr::zero());
+      assert_eq!(BLTInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/bltu.rs
+++ b/jolt-core/src/jolt/instruction/bltu.rs
@@ -21,6 +21,7 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
       jolt_instruction_test!(BLTUInstruction(x, y), (x < y).into());
+      assert_eq!(BLTUInstruction(x, y).lookup_entry::<Fr>(C, M), (x < y).into());
     }
     for _ in 0..256 {
       let x = rng.next_u64();

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -46,10 +46,12 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
       jolt_instruction_test!(BNEInstruction(x, y), (x != y).into());
+      assert_eq!(BNEInstruction(x, y).lookup_entry::<Fr>(C, M), (x != y).into());
     }
     for _ in 0..256 {
       let x = rng.next_u64();
       jolt_instruction_test!(BNEInstruction(x, x), Fr::zero());
+      assert_eq!(BNEInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/jal.rs
+++ b/jolt-core/src/jolt/instruction/jal.rs
@@ -74,6 +74,7 @@ mod test {
       let (x, y) = (rng.next_u32(), rng.next_u32());
       let z = x.overflowing_add(y.overflowing_add(4).0).0;
       jolt_instruction_test!(JALInstruction(x as u64, y as u64), z.into());
+      assert_eq!(JALInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M), z.into());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/jalr.rs
+++ b/jolt-core/src/jolt/instruction/jalr.rs
@@ -77,6 +77,7 @@ mod test {
       let (x, y) = (rng.next_u32(), rng.next_u32());
       let z = x.overflowing_add(y.overflowing_add(4).0).0;
       jolt_instruction_test!(JALRInstruction(x as u64, y as u64), (z - z % 2).into());
+      assert_eq!(JALRInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M), (z - z % 2).into());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -45,6 +45,7 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
       jolt_instruction_test!(ORInstruction(x, y), (x | y).into());
+      assert_eq!(ORInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M), (x | y).into());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/sll.rs
+++ b/jolt-core/src/jolt/instruction/sll.rs
@@ -77,6 +77,7 @@ mod test {
       let entry: u64 = x.checked_shl((y % 64) as u32).unwrap_or(0);
 
       jolt_instruction_test!(SLLInstruction(x, y), entry.into());
+      assert_eq!(SLLInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M), entry.into());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -77,10 +77,12 @@ mod test {
       let x = rng.next_u64() as i64;
       let y = rng.next_u64() as i64;
       jolt_instruction_test!(SLTInstruction(x, y), (x < y).into());
+      assert_eq!(SLTInstruction(x, y).lookup_entry::<Fr>(C, M), (x < y).into());
     }
     for _ in 0..256 {
       let x = rng.next_u64() as i64;
       jolt_instruction_test!(SLTInstruction(x, x), Fr::zero());
+      assert_eq!(SLTInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -53,10 +53,12 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
       jolt_instruction_test!(SLTUInstruction(x, y), (x < y).into());
+      assert_eq!(SLTUInstruction(x, y).lookup_entry::<Fr>(C, M), (x < y).into());
     }
     for _ in 0..256 {
       let x = rng.next_u64();
       jolt_instruction_test!(SLTUInstruction(x, x), Fr::zero());
+      assert_eq!(SLTUInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -73,8 +73,7 @@ mod test {
     const C: usize = 6;
     const M: usize = 1 << 22;
 
-    for i in 0..8 {
-      println!("i = {}", i);
+    for _ in 0..8 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
 
       let entry: i64 = (x as i64).checked_shr((y % 64) as u32).unwrap_or(0);

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -73,12 +73,14 @@ mod test {
     const C: usize = 6;
     const M: usize = 1 << 22;
 
-    for _ in 0..8 {
+    for i in 0..8 {
+      println!("i = {}", i);
       let (x, y) = (rng.next_u64(), rng.next_u64());
 
       let entry: i64 = (x as i64).checked_shr((y % 64) as u32).unwrap_or(0);
 
       jolt_instruction_test!(SRAInstruction(x, y), (entry as u64).into());
+      assert_eq!(SRAInstruction(x, y).lookup_entry::<Fr>(C, M), (entry as u64).into());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -74,6 +74,7 @@ mod test {
       let entry: u64 = x.checked_shr((y % 64) as u32).unwrap_or(0);
 
       jolt_instruction_test!(SRLInstruction(x, y), entry.into());
+      assert_eq!(SRLInstruction(x, y).lookup_entry::<Fr>(C, M), entry.into());
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -73,6 +73,7 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u32(), rng.next_u32());
       jolt_instruction_test!(SUBInstruction(x as u64, y as u64), (x.overflowing_sub(y)).0.into());
+      assert_eq!(SUBInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M), (x.overflowing_sub(y).0.into()));
     }
   }
 }

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -45,6 +45,7 @@ mod test {
     for _ in 0..256 {
       let (x, y) = (rng.next_u64(), rng.next_u64());
       jolt_instruction_test!(XORInstruction(x, y), (x ^ y).into());
+      assert_eq!(XORInstruction(x, y).lookup_entry::<Fr>(C, M), (x ^ y).into());
     }
   }
 }

--- a/jolt-core/src/jolt/subtable/srl.rs
+++ b/jolt-core/src/jolt/subtable/srl.rs
@@ -74,10 +74,17 @@ impl<F: PrimeField, const CHUNK_INDEX: usize> LassoSubtable<F> for SrlSubtable<F
         0
       };
 
-      let shift_x_by_k = (m..b)
+      // the most significant chunk might be shorter 
+      let this_chunk_length = if (b * (CHUNK_INDEX + 1)) > MAX_SHIFT {
+        b - ((b * (CHUNK_INDEX + 1)) - MAX_SHIFT)
+      } else {
+        b
+      };
+
+      let shift_x_by_k = (m..this_chunk_length)
         .enumerate()
-        .map(|(_, j)| F::from(1_u64 << (b * CHUNK_INDEX + j - k)) * x[b - 1 - j])
-        .fold(F::zero(), |acc, val| acc + val);
+        .map(|(_, j)| F::from((2_u64.pow((b * CHUNK_INDEX + j - k) as u32))) * x[b - 1 - j])
+        .fold(F::zero(), |acc, val: F| acc + val);
 
       result += eq_term * shift_x_by_k;
     }

--- a/jolt-core/src/utils/instruction_utils.rs
+++ b/jolt-core/src/utils/instruction_utils.rs
@@ -55,7 +55,7 @@ pub fn add_and_chunk_operands(x: u128, y: u128, C: usize, log_M: usize) -> Vec<u
     let output_num_bits = C * log_M;
     if output_num_bits != 128 {
       // if 128, handeled by normal overflow checking
-      let max_z = 1 << (C * log_M);
+      let max_z = 1 << (C * log_M + 1);
       assert!(x + y < max_z);
     }
   }


### PR DESCRIPTION
Given a JoltInstruction object, this function produces the lookup entry. It does so by obtaining each subtable entry using the MLE evaluations (not by materializing the subtables) and then combining them, as before.

I've added a test for each instruction on top of the existing test (which materializes subtables). 

This function will be needed to generate the list of lookup outputs to feed into the R1CS. 

