### PR TITLE
Add plot CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Note: requires nightly Rust
 -   `cargo run --release -- -p jolt-core --name <bench_name> --chart`: Display performance gant chart
 -   `cargo run --release -p jolt-core --features ark-msm -- --name <bench_name>`: Run without MSM small field optimizations
 
+## Performance plots
+
+Example:
+```
+cargo run -p jolt-core --release -- plot  --bench bytecode instruction-lookups read-write-memory --out test.svg --num-cycles 65536 131072 262144 524288  --bytecode-size 65536 --memory-size 2097152
+```
+
 ## Flamegraph
 
 Requires `inferno`:

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     # authors who contributed to Lasso
     "Michael Zhu <mzhu@a16z.com>",
     "Sam Ragsdale <sragsdale@a16z.com>",
-    "Noah Citron <ncitron@a16z.com>"
+    "Noah Citron <ncitron@a16z.com>",
 ]
 edition = "2021"
 description = "The lookup singularity. Based on Spartan; built on Arkworks."
@@ -46,6 +46,7 @@ seq-macro = "0.3.3"
 ark-curve25519 = "0.4.0"
 rgb = "0.8.37"
 textplots = "0.8.4"
+plotters = "0.3.5"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 tracing-texray = "0.2.0"
@@ -71,7 +72,13 @@ name = "liblasso"
 path = "src/lib.rs"
 
 [features]
-default = ["ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-ff/asm", "multicore"]
+default = [
+    "ark-ec/parallel",
+    "ark-ff/parallel",
+    "ark-std/parallel",
+    "ark-ff/asm",
+    "multicore",
+]
 multicore = ["rayon"]
 ark-msm = [] # run with arkworks MSM without small field element optimization
 dhat-heap = []

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -44,6 +44,8 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 num-integer = "0.1.45"
 seq-macro = "0.3.3"
 ark-curve25519 = "0.4.0"
+rgb = "0.8.37"
+textplots = "0.8.4"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 tracing-texray = "0.2.0"

--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -35,169 +35,53 @@ use merlin::Transcript;
 use rand_chacha::rand_core::RngCore;
 use rand_core::SeedableRng;
 
-#[derive(Debug, Clone, clap::ValueEnum)]
+#[derive(Debug, Copy, Clone, clap::ValueEnum)]
 pub enum BenchType {
-    JoltDemo,
-    Halo2Comparison,
-    RV32,
     Poly,
     EverythingExceptR1CS,
+    Bytecode,
+    ReadWriteMemory,
+    InstructionLookups,
 }
 
 #[allow(unreachable_patterns)] // good errors on new BenchTypes
 pub fn benchmarks(
     bench_type: BenchType,
     num_cycles: Option<usize>,
+    memory_size: Option<usize>,
+    bytecode_size: Option<usize>,
 ) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     match bench_type {
-        BenchType::JoltDemo => jolt_demo_benchmarks(),
-        BenchType::Halo2Comparison => halo2_comparison_benchmarks(),
-        BenchType::RV32 => rv32i_lookup_benchmarks(num_cycles),
         BenchType::Poly => dense_ml_poly(),
-        BenchType::EverythingExceptR1CS => prove_e2e_except_r1cs(num_cycles),
+        BenchType::EverythingExceptR1CS => {
+            prove_e2e_except_r1cs(num_cycles, memory_size, bytecode_size)
+        }
+        BenchType::Bytecode => prove_bytecode(num_cycles, bytecode_size),
+        BenchType::ReadWriteMemory => prove_memory(num_cycles, memory_size, bytecode_size),
+        BenchType::InstructionLookups => prove_instruction_lookups(num_cycles),
         _ => panic!("BenchType does not have a mapping"),
     }
 }
 
-fn jolt_demo_benchmarks() -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
-    const C: usize = 4;
-    const M: usize = 1 << 16;
-    vec![
-        (
-            tracing::info_span!("XOR(2^10)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 10),
-        ),
-        (
-            tracing::info_span!("XOR(2^12)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 12),
-        ),
-        (
-            tracing::info_span!("XOR(2^14)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 14),
-        ),
-        (
-            tracing::info_span!("XOR(2^16)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 16),
-        ),
-        (
-            tracing::info_span!("XOR(2^18)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 18),
-        ),
-        (
-            tracing::info_span!("XOR(2^20)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 20),
-        ),
-        (
-            tracing::info_span!("XOR(2^22)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 22),
-        ),
-    ]
-}
-
-fn halo2_comparison_benchmarks() -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
-    const C: usize = 1;
-    const M: usize = 1 << 16;
-    vec![
-        (
-            tracing::info_span!("XOR(2^10)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 10),
-        ),
-        (
-            tracing::info_span!("XOR(2^12)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 12),
-        ),
-        (
-            tracing::info_span!("XOR(2^14)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 14),
-        ),
-        (
-            tracing::info_span!("XOR(2^16)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 16),
-        ),
-        (
-            tracing::info_span!("XOR(2^18)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 18),
-        ),
-        (
-            tracing::info_span!("XOR(2^20)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 20),
-        ),
-        (
-            tracing::info_span!("XOR(2^22)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 22),
-        ),
-        (
-            tracing::info_span!("XOR(2^24)"),
-            random_surge_test::<C, M>(/* num_ops */ 1 << 24),
-        ),
-    ]
-}
-
-fn rv32i_lookup_benchmarks(num_cycles: Option<usize>) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
-    // let mut rng = rand::rngs::StdRng::seed_from_u64(1234567890);
-    let mut rng = test_rng();
-
-    let num_cycles = num_cycles.unwrap_or(64_000);
-    // let ops: Vec<RV32I> = vec![RV32I::random_instruction(&mut rng); num_cycles];
-    let ops_sample: Vec<RV32I> = vec![
-        RV32I::ADD(ADDInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::AND(ANDInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::BEQ(BEQInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::BGE(BGEInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::BGEU(BGEUInstruction(
-            rng.next_u32() as u64,
-            rng.next_u32() as u64,
-        )),
-        RV32I::BLT(BLTInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::BLTU(BLTUInstruction(
-            rng.next_u32() as u64,
-            rng.next_u32() as u64,
-        )),
-        RV32I::BNE(BNEInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::JAL(JALInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::JALR(JALRInstruction(
-            rng.next_u32() as u64,
-            rng.next_u32() as u64,
-        )),
-        RV32I::OR(ORInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::SLL(SLLInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::SRA(SRAInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::SRL(SRLInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::SUB(SUBInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-        RV32I::XOR(XORInstruction(rng.next_u32() as u64, rng.next_u32() as u64)),
-    ];
-    let mut ops: Vec<RV32I> = vec![];
-    while ops.len() < num_cycles {
-        ops.extend(ops_sample.clone());
-    }
-    println!("Running {:?}", ops.len());
-
-    let work = Box::new(|| {
-        let mut prover_transcript = Transcript::new(b"example");
-        let mut random_tape = RandomTape::new(b"test_tape");
-        let proof: InstructionLookupsProof<Fr, EdwardsProjective> =
-            RV32IJoltVM::prove_instruction_lookups(ops, &mut prover_transcript, &mut random_tape);
-        let mut verifier_transcript = Transcript::new(b"example");
-        assert!(RV32IJoltVM::verify_instruction_lookups(proof, &mut verifier_transcript).is_ok());
-    });
-    vec![(tracing::info_span!("RV32I"), work)]
-}
-
-fn prove_e2e_except_r1cs(num_cycles: Option<usize>) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
+fn prove_e2e_except_r1cs(
+    num_cycles: Option<usize>,
+    memory_size: Option<usize>,
+    bytecode_size: Option<usize>,
+) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     let mut rng = rand::rngs::StdRng::seed_from_u64(1234567890);
 
-    const MEMORY_SIZE: usize = 1 << 22; // 4,194,304 = 4 MB
-    const BYTECODE_SIZE: usize = 1 << 16; // 65,536 = 64 kB
+    let memory_size = memory_size.unwrap_or(1 << 22); // 4,194,304 = 4 MB
+    let bytecode_size = bytecode_size.unwrap_or(1 << 16); // 65,536 = 64 kB
     let num_cycles = num_cycles.unwrap_or(1 << 16); // 65,536
 
     let ops: Vec<RV32I> = vec![RV32I::random_instruction(&mut rng); num_cycles];
 
-    let bytecode: Vec<ELFInstruction> = (0..BYTECODE_SIZE)
+    let bytecode: Vec<ELFInstruction> = (0..bytecode_size)
         .map(|i| ELFInstruction::random(i, &mut rng))
         .collect();
     // 7 memory ops per instruction, rounded up to still be a power of 2
-    let memory_trace = random_memory_trace(&bytecode, MEMORY_SIZE, 8 * num_cycles, &mut rng);
-    let mut bytecode_rows: Vec<ELFRow> = (0..BYTECODE_SIZE)
+    let memory_trace = random_memory_trace(&bytecode, memory_size, 8 * num_cycles, &mut rng);
+    let mut bytecode_rows: Vec<ELFRow> = (0..bytecode_size)
         .map(|i| ELFRow::random(i, &mut rng))
         .collect();
     let bytecode_trace = random_bytecode_trace(&bytecode_rows, num_cycles, &mut rng);
@@ -216,27 +100,80 @@ fn prove_e2e_except_r1cs(num_cycles: Option<usize>) -> Vec<(tracing::Span, Box<d
         let _: InstructionLookupsProof<Fr, EdwardsProjective> =
             RV32IJoltVM::prove_instruction_lookups(ops, &mut transcript, &mut random_tape);
     });
-    vec![(tracing::info_span!("E2E (except R1CS)"), work)]
+    vec![(
+        tracing::info_span!("prove_bytecode + prove_memory + prove_instruction_lookups"),
+        work,
+    )]
 }
 
-fn random_surge_test<const C: usize, const M: usize>(num_ops: usize) -> Box<dyn FnOnce()> {
+fn prove_bytecode(
+    num_cycles: Option<usize>,
+    bytecode_size: Option<usize>,
+) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     let mut rng = rand::rngs::StdRng::seed_from_u64(1234567890);
-    let ops: Vec<XORInstruction> = vec![XORInstruction::default().random(&mut rng); num_ops];
 
-    let func = move || {
-        let mut prover_transcript = Transcript::new(b"test_transcript");
-        let surge = <Surge<Fr, EdwardsProjective, XORInstruction, C, M>>::new(ops.clone());
-        let proof = surge.prove(&mut prover_transcript);
+    let bytecode_size = bytecode_size.unwrap_or(1 << 16); // 65,536 = 64 kB
+    let num_cycles = num_cycles.unwrap_or(1 << 16); // 65,536
 
-        let mut verifier_transcript = Transcript::new(b"test_transcript");
-        <Surge<Fr, EdwardsProjective, XORInstruction, C, M>>::verify(
-            proof,
-            &mut verifier_transcript,
-        )
-        .expect("should work");
-    };
+    let bytecode: Vec<ELFInstruction> = (0..bytecode_size)
+        .map(|i| ELFInstruction::random(i, &mut rng))
+        .collect();
+    let mut bytecode_rows: Vec<ELFRow> = (0..bytecode_size)
+        .map(|i| ELFRow::random(i, &mut rng))
+        .collect();
+    let bytecode_trace = random_bytecode_trace(&bytecode_rows, num_cycles, &mut rng);
 
-    Box::new(func)
+    let work = Box::new(|| {
+        let mut transcript = Transcript::new(b"example");
+        let mut random_tape: RandomTape<EdwardsProjective> = RandomTape::new(b"test_tape");
+        let _ = RV32IJoltVM::prove_bytecode(
+            bytecode_rows,
+            bytecode_trace,
+            &mut transcript,
+            &mut random_tape,
+        );
+    });
+    vec![(tracing::info_span!("prove_bytecode"), work)]
+}
+
+fn prove_memory(
+    num_cycles: Option<usize>,
+    memory_size: Option<usize>,
+    bytecode_size: Option<usize>,
+) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(1234567890);
+
+    let memory_size = memory_size.unwrap_or(1 << 22); // 4,194,304 = 4 MB
+    let bytecode_size = bytecode_size.unwrap_or(1 << 16); // 65,536 = 64 kB
+    let num_cycles = num_cycles.unwrap_or(1 << 16); // 65,536
+
+    let bytecode: Vec<ELFInstruction> = (0..bytecode_size)
+        .map(|i| ELFInstruction::random(i, &mut rng))
+        .collect();
+    // 7 memory ops per instruction, rounded up to still be a power of 2
+    let memory_trace = random_memory_trace(&bytecode, memory_size, 8 * num_cycles, &mut rng);
+
+    let work = Box::new(|| {
+        let mut transcript = Transcript::new(b"example");
+        let mut random_tape: RandomTape<EdwardsProjective> = RandomTape::new(b"test_tape");
+        let _ =
+            RV32IJoltVM::prove_memory(bytecode, memory_trace, &mut transcript, &mut random_tape);
+    });
+    vec![(tracing::info_span!("prove_memory"), work)]
+}
+
+fn prove_instruction_lookups(num_cycles: Option<usize>) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(1234567890);
+
+    let num_cycles = num_cycles.unwrap_or(1 << 16); // 65,536
+    let ops: Vec<RV32I> = vec![RV32I::random_instruction(&mut rng); num_cycles];
+
+    let work = Box::new(|| {
+        let mut transcript = Transcript::new(b"example");
+        let mut random_tape: RandomTape<EdwardsProjective> = RandomTape::new(b"test_tape");
+        RV32IJoltVM::prove_instruction_lookups(ops, &mut transcript, &mut random_tape);
+    });
+    vec![(tracing::info_span!("prove_instruction_lookups"), work)]
 }
 
 fn dense_ml_poly() -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -3,6 +3,7 @@ use ark_ff::PrimeField;
 use merlin::Transcript;
 use std::any::TypeId;
 use strum::{EnumCount, IntoEnumIterator};
+use textplots::{Chart, Plot, Shape};
 
 use crate::jolt::{
     instruction::{sltu::SLTUInstruction, JoltInstruction, Opcode},

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -138,10 +138,7 @@ pub trait Jolt<F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize, co
         transcript: &mut Transcript,
         random_tape: &mut RandomTape<G>,
     ) -> ReadWriteMemoryProof<F, G> {
-        const MAX_TRACE_SIZE: usize = 1 << 22;
-        // TODO: Support longer traces
-        assert!(memory_trace.len() <= MAX_TRACE_SIZE);
-
+        let memory_trace_size = memory_trace.len();
         let (memory, read_timestamps) = ReadWriteMemory::new(bytecode, memory_trace, transcript);
         let batched_polys = memory.batch();
         let commitment: MemoryCommitment<G> = ReadWriteMemory::commit(&batched_polys);
@@ -160,14 +157,16 @@ pub trait Jolt<F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize, co
             .map(|(i, &ts)| SLTUInstruction(ts, i as u64 + 1))
             .collect();
 
+        let surge_M = memory_trace_size.next_power_of_two();
         let timestamp_validity_proof =
-            <Surge<F, G, SLTUInstruction, 2, MAX_TRACE_SIZE>>::new(timestamp_validity_lookups)
+            <Surge<F, G, SLTUInstruction, 2>>::new(timestamp_validity_lookups, surge_M)
                 .prove(transcript);
 
         ReadWriteMemoryProof {
             memory_checking_proof,
             commitment,
             timestamp_validity_proof,
+            memory_trace_size,
         }
     }
 
@@ -175,15 +174,16 @@ pub trait Jolt<F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize, co
         proof: ReadWriteMemoryProof<F, G>,
         transcript: &mut Transcript,
     ) -> Result<(), ProofVerifyError> {
-        const MAX_TRACE_SIZE: usize = 1 << 22;
         ReadWriteMemory::verify_memory_checking(
             proof.memory_checking_proof,
             &proof.commitment,
             transcript,
         )?;
-        <Surge<F, G, SLTUInstruction, 2, MAX_TRACE_SIZE>>::verify(
+        let surge_M = proof.memory_trace_size.next_power_of_two();
+        <Surge<F, G, SLTUInstruction, 2>>::verify(
             proof.timestamp_validity_proof,
             transcript,
+            surge_M,
         )
     }
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -100,6 +100,7 @@ where
     >,
     pub commitment: MemoryCommitment<G>,
     pub timestamp_validity_proof: SurgeProof<F, G>,
+    pub memory_trace_size: usize,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/jolt-core/src/main.rs
+++ b/jolt-core/src/main.rs
@@ -1,9 +1,12 @@
-use clap::{Parser, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use itertools::izip;
 use liblasso::benches::bench::{benchmarks, BenchType};
-use std::{fs::File, io::BufWriter};
-use tracing_flame::FlameLayer;
-use tracing_subscriber::{self, fmt, fmt::format::FmtSpan, prelude::*, registry::Registry};
+use rgb::RGB8;
+use std::{fs::File, io::BufWriter, time::Instant};
+use textplots::{Chart, ColorPlot, Plot, Shape};
 use tracing_chrome::ChromeLayerBuilder;
+use tracing_flame::FlameLayer;
+use tracing_subscriber::{self, fmt, fmt::format::FmtSpan, prelude::*};
 
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]
@@ -12,6 +15,18 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 /// Search for a pattern in a file and display the lines that contain it.
 #[derive(Parser, Debug)]
 struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Trace(TraceArgs),
+    Plot(PlotArgs),
+}
+
+#[derive(Args, Debug)]
+struct TraceArgs {
     /// Output format
     #[clap(short, long, value_enum, default_value_t = Format::Default)]
     format: Format,
@@ -21,8 +36,25 @@ struct Cli {
     name: BenchType,
 
     /// Number of cycles to run the benchmark for
-    #[clap(long)]
+    #[clap(short, long)]
     num_cycles: Option<usize>,
+}
+
+#[derive(Args, Debug)]
+struct PlotArgs {
+    /// Type of benchmark to run
+    #[clap(long, value_enum, num_args = 1..)]
+    bench: Vec<BenchType>,
+
+    /// Number of cycles to run the benchmark for
+    #[clap(short, long, num_args = 1..)]
+    num_cycles: Vec<usize>,
+
+    #[clap(short, long, num_args = 1..)]
+    memory_size: Vec<usize>,
+
+    #[clap(short, long, num_args = 1..)]
+    bytecode_size: Vec<usize>,
 }
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -30,28 +62,141 @@ enum Format {
     Default,
     Texray,
     Flamegraph,
-    Chrome
-}
-
-fn setup_global_subscriber() -> impl Drop {
-    let fmt_layer = fmt::Layer::default();
-
-    let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
-
-    tracing_subscriber::registry()
-        .with(fmt_layer)
-        .with(flame_layer)
-        .init();
-
-    _guard
+    Chrome,
 }
 
 fn main() {
-    let args = Cli::parse();
+    let cli = Cli::parse();
 
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();
 
+    match cli.command {
+        Commands::Trace(args) => trace(args),
+        Commands::Plot(args) => plot(args),
+    }
+}
+
+fn bench_to_color(bench_type: &BenchType) -> RGB8 {
+    match bench_type {
+        BenchType::EverythingExceptR1CS => RGB8 {
+            r: 255,
+            g: 255,
+            b: 255,
+        }, // white
+        BenchType::ReadWriteMemory => RGB8 { r: 255, g: 0, b: 0 }, // red
+        BenchType::Bytecode => RGB8 { r: 0, g: 0, b: 255 },        // blue
+        BenchType::InstructionLookups => RGB8 { r: 0, g: 255, b: 0 }, // green
+        _ => panic!("Unsupported bench type"),
+    }
+}
+
+fn plot(args: PlotArgs) {
+    let mut x: Vec<Vec<f32>> = Vec::with_capacity(args.bench.len());
+    let mut y: Vec<Vec<f32>> = Vec::with_capacity(args.bench.len());
+
+    for bench_type in &args.bench {
+        if args.num_cycles.len() > 1 {
+            assert!(args.memory_size.len() == 1);
+            assert!(args.bytecode_size.len() == 1);
+
+            let x_i = args.num_cycles.iter().map(|z| *z as f32).collect();
+            let mut y_i = Vec::with_capacity(args.num_cycles.len());
+            for num_cycles in &args.num_cycles {
+                for (_, bench) in benchmarks(
+                    *bench_type,
+                    Some(*num_cycles),
+                    Some(args.memory_size[0]),
+                    Some(args.bytecode_size[0]),
+                )
+                .into_iter()
+                {
+                    let now = Instant::now();
+                    bench();
+                    y_i.push(now.elapsed().as_micros() as f32 / 1_000_000.0); // time in seconds
+                }
+            }
+            x.push(x_i);
+            y.push(y_i);
+        }
+
+        if args.memory_size.len() > 1 {
+            assert!(args.num_cycles.len() == 1);
+            assert!(args.bytecode_size.len() == 1);
+
+            let x_i = args.memory_size.iter().map(|z| *z as f32).collect();
+            let mut y_i = Vec::with_capacity(args.memory_size.len());
+            for memory_size in &args.memory_size {
+                for (_, bench) in benchmarks(
+                    *bench_type,
+                    Some(args.num_cycles[0]),
+                    Some(*memory_size),
+                    Some(args.bytecode_size[0]),
+                )
+                .into_iter()
+                {
+                    let now = Instant::now();
+                    bench();
+                    y_i.push(now.elapsed().as_micros() as f32 / 1_000_000.0); // time in seconds
+                }
+            }
+            x.push(x_i);
+            y.push(y_i);
+        }
+
+        if args.bytecode_size.len() > 1 {
+            assert!(args.num_cycles.len() == 1);
+            assert!(args.memory_size.len() == 1);
+
+            let x_i = args.bytecode_size.iter().map(|z| *z as f32).collect();
+            let mut y_i = Vec::with_capacity(args.bytecode_size.len());
+            for bytecode_size in &args.bytecode_size {
+                for (_, bench) in benchmarks(
+                    *bench_type,
+                    Some(args.num_cycles[0]),
+                    Some(args.memory_size[0]),
+                    Some(*bytecode_size),
+                )
+                .into_iter()
+                {
+                    let now = Instant::now();
+                    bench();
+                    y_i.push(now.elapsed().as_micros() as f32 / 1_000_000.0); // time in seconds
+                }
+            }
+            x.push(x_i);
+            y.push(y_i);
+        }
+    }
+
+    let xmin = x
+        .iter()
+        .flatten()
+        .min_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    let xmax = x
+        .iter()
+        .flatten()
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    let ymax = y
+        .iter()
+        .flatten()
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+
+    let mut chart = &mut Chart::new_with_y_range(120, 80, *xmin, *xmax, 0.0, *ymax);
+    let points: Vec<_> = izip!(x, y)
+        .map(|(x_i, y_i)| izip!(x_i, y_i).collect::<Vec<(f32, f32)>>())
+        .collect();
+    let lines: Vec<_> = points.iter().map(|p| Shape::Lines(p)).collect();
+    for (i, bench_type) in args.bench.iter().enumerate() {
+        chart = chart.linecolorplot(&lines[i], bench_to_color(bench_type));
+    }
+    chart.display();
+}
+
+fn trace(args: TraceArgs) {
     match args.format {
         Format::Default => {
             let collector = tracing_subscriber::fmt()
@@ -60,7 +205,7 @@ fn main() {
                 .finish();
             tracing::subscriber::set_global_default(collector)
                 .expect("setting tracing default failed");
-            for (span, bench) in benchmarks(args.name, args.num_cycles).into_iter() {
+            for (span, bench) in benchmarks(args.name, args.num_cycles, None, None).into_iter() {
                 span.to_owned().in_scope(|| {
                     bench();
                     tracing::info!("Bench Complete");
@@ -69,13 +214,19 @@ fn main() {
         }
         Format::Texray => {
             tracing_texray::init();
-            for (span, bench) in benchmarks(args.name, args.num_cycles).into_iter() {
+            for (span, bench) in benchmarks(args.name, args.num_cycles, None, None).into_iter() {
                 tracing_texray::examine(span.to_owned()).in_scope(bench);
             }
         }
         Format::Flamegraph => {
-            let _guard = setup_global_subscriber();
-            for (span, bench) in benchmarks(args.name, args.num_cycles).into_iter() {
+            let fmt_layer = fmt::Layer::default();
+            let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
+            tracing_subscriber::registry()
+                .with(fmt_layer)
+                .with(flame_layer)
+                .init();
+
+            for (span, bench) in benchmarks(args.name, args.num_cycles, None, None).into_iter() {
                 span.to_owned().in_scope(|| {
                     bench();
                     tracing::info!("Bench Complete");
@@ -86,7 +237,7 @@ fn main() {
             let (chrome_layer, _guard) = ChromeLayerBuilder::new().build();
             tracing_subscriber::registry().with(chrome_layer).init();
             println!("Running tracing-chrome. Files will be saved as trace-<some timestamp>.json and can be viewed in chrome://tracing.");
-            for (span, bench) in benchmarks(args.name, args.num_cycles).into_iter() {
+            for (span, bench) in benchmarks(args.name, args.num_cycles, None, None).into_iter() {
                 span.to_owned().in_scope(|| {
                     bench();
                     tracing::info!("Bench Complete");

--- a/jolt-core/src/main.rs
+++ b/jolt-core/src/main.rs
@@ -47,16 +47,19 @@ struct PlotArgs {
     #[clap(long, value_enum, num_args = 1..)]
     bench: Vec<BenchType>,
 
+    /// SVG output file path
     #[clap(short, long)]
     out: Option<String>,
 
-    /// Number of cycles to run the benchmark for
+    /// Number of cycles to run benchmarks for
     #[clap(short, long, num_args = 1..)]
     num_cycles: Vec<usize>,
 
+    /// Size of read-write memory to run benchmarks with
     #[clap(short, long, num_args = 1..)]
     memory_size: Vec<usize>,
 
+    /// Size of bytecode to run benchmarks with
     #[clap(short, long, num_args = 1..)]
     bytecode_size: Vec<usize>,
 }
@@ -118,6 +121,28 @@ fn plot_x_label(args: &PlotArgs) -> String {
         "Memory size (B)".to_owned()
     } else {
         "Bytecode size (B)".to_owned()
+    }
+}
+
+fn plot_title(args: &PlotArgs) -> String {
+    if args.num_cycles.len() > 1 {
+        format!(
+            "Proving times (memory_size = {}, bytecode_size = {})",
+            args.memory_size[0], args.bytecode_size[0]
+        )
+        .to_owned()
+    } else if args.memory_size.len() > 1 {
+        format!(
+            "Proving times (num_cycles = {}, bytecode_size = {})",
+            args.num_cycles[0], args.bytecode_size[0]
+        )
+        .to_owned()
+    } else {
+        format!(
+            "Proving times (num_cycles = {}, memory_size = {})",
+            args.num_cycles[0], args.memory_size[0]
+        )
+        .to_owned()
     }
 }
 
@@ -233,7 +258,7 @@ fn svg_plot(
         .collect();
 
     let mut chart = ChartBuilder::on(&root)
-        .caption("Proving times", ("sans-serif", (5).percent_height()))
+        .caption(plot_title(args), ("sans-serif", (5).percent_height()))
         .set_label_area_size(LabelAreaPosition::Left, (8).percent())
         .set_label_area_size(LabelAreaPosition::Bottom, (4).percent())
         .margin((1).percent())

--- a/jolt-core/src/main.rs
+++ b/jolt-core/src/main.rs
@@ -261,7 +261,7 @@ fn svg_plot(
         .caption(plot_title(args), ("sans-serif", (5).percent_height()))
         .set_label_area_size(LabelAreaPosition::Left, (8).percent())
         .set_label_area_size(LabelAreaPosition::Bottom, (4).percent())
-        .margin((1).percent())
+        .margin((8).percent())
         .build_cartesian_2d(
             (*xmin..*xmax).log_scale().with_key_points(x_tick_labels),
             0.0..*ymax,
@@ -286,6 +286,16 @@ fn svg_plot(
             ))?
             .label(bench_to_label(bench_type))
             .legend(move |(x, y)| Rectangle::new([(x, y - 5), (x + 10, y + 5)], color.filled()));
+        chart.draw_series(PointSeries::of_element(
+            points[i].clone(),
+            4,
+            Palette99::pick(i).mix(0.9).filled(),
+            &|coord, size, style| {
+                EmptyElement::at(coord)
+                    + Circle::new((0, 0), size, style)
+                    + Text::new(format!("{:.3}s", coord.1), (0, 15), ("sans-serif", 14))
+            },
+        ))?;
     }
 
     chart.configure_series_labels().border_style(BLACK).draw()?;


### PR DESCRIPTION
Adds `plot` CLI command to plot runtime of proving benchmarks (prove_bytecode, prove_memory, prove_instruction_lookups) against one of three independent variables: bytecode size, memory size, or # cycles (fixing the other two). Outputs to the terminal using textplots, and optionally saves an SVG file using plotters too. 