### PR TITLE
Optimized materialization of `EQ` tables

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -80,3 +80,7 @@ harness = false
 [[bench]]
 name = "dense_mlpoly"
 harness = false
+
+[[bench]]
+name = "materialize"
+harness = false

--- a/jolt-core/benches/materialize.rs
+++ b/jolt-core/benches/materialize.rs
@@ -1,0 +1,20 @@
+use ark_curve25519::Fr;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use liblasso::jolt::subtable::eq::EqSubtable;
+use liblasso::jolt::subtable::LassoSubtable;
+
+fn materialize_subtable(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DenseMLPoly Evaluation");
+
+    group.bench_function("Materialize EQ subtable", |b| {
+        b.iter(|| {
+            let table = EqSubtable::<Fr>::new();
+            black_box(table.materialize(1 << 16));
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, materialize_subtable);
+criterion_main!(benches);

--- a/jolt-core/benches/materialize.rs
+++ b/jolt-core/benches/materialize.rs
@@ -1,6 +1,7 @@
 use ark_curve25519::Fr;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use liblasso::jolt::subtable::eq::EqSubtable;
+use liblasso::jolt::subtable::eq_abs::EqAbsSubtable;
 use liblasso::jolt::subtable::LassoSubtable;
 
 fn materialize_subtable(c: &mut Criterion) {
@@ -9,6 +10,13 @@ fn materialize_subtable(c: &mut Criterion) {
     group.bench_function("Materialize EQ subtable", |b| {
         b.iter(|| {
             let table = EqSubtable::<Fr>::new();
+            black_box(table.materialize(1 << 16));
+        })
+    });
+
+    group.bench_function("Materialize EQAbs subtable", |b| {
+        b.iter(|| {
+            let table = EqAbsSubtable::<Fr>::new();
             black_box(table.materialize(1 << 16));
         })
     });

--- a/jolt-core/src/jolt/subtable/eq.rs
+++ b/jolt-core/src/jolt/subtable/eq.rs
@@ -20,14 +20,13 @@ impl<F: PrimeField> EqSubtable<F> {
 
 impl<F: PrimeField> LassoSubtable<F> for EqSubtable<F> {
     fn materialize(&self, M: usize) -> Vec<F> {
-        let mut entries: Vec<F> = Vec::with_capacity(M);
+        let mut entries: Vec<F> = vec![F::zero(); M];
         let bits_per_operand = (log2(M) / 2) as usize;
 
         // Materialize table entries in order where (x | y) ranges 0..M
-        for idx in 0..M {
-            let (x, y) = split_bits(idx, bits_per_operand);
-            let row = if x == y { F::one() } else { F::zero() };
-            entries.push(row);
+        for idx in 0..(1 << bits_per_operand) {
+            let concat_idx = idx | (idx << bits_per_operand);
+            entries[concat_idx] = F::one();
         }
         entries
     }

--- a/jolt-core/src/jolt/subtable/eq.rs
+++ b/jolt-core/src/jolt/subtable/eq.rs
@@ -3,7 +3,6 @@ use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
-use crate::utils::split_bits;
 
 #[derive(Default)]
 pub struct EqSubtable<F: PrimeField> {

--- a/jolt-core/src/jolt/subtable/eq.rs
+++ b/jolt-core/src/jolt/subtable/eq.rs
@@ -23,6 +23,8 @@ impl<F: PrimeField> LassoSubtable<F> for EqSubtable<F> {
         let bits_per_operand = (log2(M) / 2) as usize;
 
         // Materialize table entries in order where (x | y) ranges 0..M
+        // Below is the optimized loop for the condition:
+        // table[x | y] = x == y
         for idx in 0..(1 << bits_per_operand) {
             let concat_idx = idx | (idx << bits_per_operand);
             entries[concat_idx] = F::one();

--- a/jolt-core/src/jolt/subtable/eq_abs.rs
+++ b/jolt-core/src/jolt/subtable/eq_abs.rs
@@ -20,21 +20,23 @@ impl<F: PrimeField> EqAbsSubtable<F> {
 
 impl<F: PrimeField> LassoSubtable<F> for EqAbsSubtable<F> {
     fn materialize(&self, M: usize) -> Vec<F> {
-        let mut entries: Vec<F> = Vec::with_capacity(M);
+        let mut entries: Vec<F> = vec![F::zero(); M];
         let bits_per_operand = (log2(M) / 2) as usize;
         // 0b01111...11
         let lower_bits_mask = (1 << (bits_per_operand - 1)) - 1;
 
         // Materialize table entries in order where (x | y) ranges 0..M
-        for idx in 0..M {
-            let (x, y) = split_bits(idx, bits_per_operand);
-            let row = if (x & lower_bits_mask) == (y & lower_bits_mask) {
-                F::one()
-            } else {
-                F::zero()
-            };
-            entries.push(row);
+        for idx in 0..(1 << (bits_per_operand)) {
+            // we set the bit in the table where x == y
+            // e.g. 01010011 | 01010011 = 1
+            let concat_index_1 = idx | (idx << bits_per_operand);
+            // we also set the bit where x == y except for their leading bit
+            // e.g. 11010011 | 01010011 = 0
+            let concat_index_2 = idx | ((idx ^ (1 << bits_per_operand - 1)) << bits_per_operand);
+            entries[concat_index_1] = F::one();
+            entries[concat_index_2] = F::one();
         }
+
         entries
     }
 

--- a/jolt-core/src/jolt/subtable/eq_abs.rs
+++ b/jolt-core/src/jolt/subtable/eq_abs.rs
@@ -21,10 +21,11 @@ impl<F: PrimeField> LassoSubtable<F> for EqAbsSubtable<F> {
     fn materialize(&self, M: usize) -> Vec<F> {
         let mut entries: Vec<F> = vec![F::zero(); M];
         let bits_per_operand = (log2(M) / 2) as usize;
-        // 0b01111...11
-        let lower_bits_mask = (1 << (bits_per_operand - 1)) - 1;
 
         // Materialize table entries in order where (x | y) ranges 0..M
+        // Below is the optimized loop for the condition:
+        // lower_bits_mask = 0b01111...11
+        // table[x | y] == (x & lower_bits_mask) == (y & lower_bits_mask)
         for idx in 0..(1 << (bits_per_operand)) {
             // we set the bit in the table where x == y
             // e.g. 01010011 | 01010011 = 1

--- a/jolt-core/src/jolt/subtable/eq_abs.rs
+++ b/jolt-core/src/jolt/subtable/eq_abs.rs
@@ -3,7 +3,6 @@ use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
-use crate::utils::split_bits;
 
 #[derive(Default)]
 pub struct EqAbsSubtable<F: PrimeField> {


### PR DESCRIPTION
Probably in the grand scheme of things these savings are negligible, but here they are:

before:
```
DenseMLPoly Evaluation/Materialize EQ subtable
                        time:   [211.17 µs 213.41 µs 216.47 µs]

DenseMLPoly Evaluation/Materialize EQAbs subtable
                        time:   [217.81 µs 223.26 µs 229.77 µs]
```
after:
```
DenseMLPoly Evaluation/Materialize EQ subtable
                        time:   [91.029 µs 92.311 µs 93.933 µs]
                        change: [-57.152% -56.489% -55.796%] (p = 0.00 < 0.05)


DenseMLPoly Evaluation/Materialize EQAbs subtable
                        time:   [90.391 µs 91.322 µs 92.320 µs]
                        change: [-58.382% -57.365% -56.325%] (p = 0.00 < 0.05)
```