### PR TITLE
Backport small MSM improvement

### DIFF
--- a/jolt-core/src/msm/mod.rs
+++ b/jolt-core/src/msm/mod.rs
@@ -117,6 +117,12 @@ fn msm_bigint_wnaf<V: VariableBaseMSM>(
 
     let num_bits = max_num_bits;
     let digits_count = (num_bits + c - 1) / c;
+    #[cfg(feature = "parallel")]
+    let scalar_digits = scalars
+        .into_par_iter()
+        .flat_map_iter(|s| make_digits(s, c, num_bits))
+        .collect::<Vec<_>>();
+    #[cfg(not(feature = "parallel"))]
     let scalar_digits = scalars
         .iter()
         .flat_map(|s| make_digits(s, c, num_bits))


### PR DESCRIPTION
Backporting https://github.com/arkworks-rs/algebra/pull/703 for 8-12% improvement when running with parallel execution.