### PR TITLE
synthesize only variables during proof (and not shape)

### DIFF
--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -151,13 +151,12 @@ impl<F: PrimeField<Repr = [u8; 32]>> Circuit<F> for JoltCircuit<F> {
     for i in 0..NUM_STEPS {
       let span = tracing::span!(tracing::Level::INFO, "circom_scotia::synthesize");
       let _guard = span.enter();
-      {
-        let witness = &jolt_witnesses[i];
-        (1..cfg.r1cs.num_inputs).chain(cfg.r1cs.num_inputs..cfg.r1cs.num_inputs + cfg.r1cs.num_aux).for_each(|i| {
-            let f = witness[i];
-            let _ = AllocatedNum::alloc(cs.namespace(|| format!("{}_{}", if i < cfg.r1cs.num_inputs { "public" } else { "aux" }, i)), || Ok(f)).unwrap();
-        });
-      }
+      let witness = &jolt_witnesses[i];
+      let total_vars = cfg.r1cs.num_inputs + cfg.r1cs.num_aux;
+      (1..total_vars).for_each(|i| {
+          let f = witness[i];
+          let _ = AllocatedNum::alloc(cs.namespace(|| format!("{}_{}", if i < cfg.r1cs.num_inputs { "public" } else { "aux" }, i)), || Ok(f)).unwrap();
+      });
       drop(_guard);
       drop(span);
     }


### PR DESCRIPTION
This synthesizes only variables when calling `JoltCircuit.synthesize`, and not the constraints. Synthesizing constraints in only needed when generating the shape and that's handled in `JoltSkeleton.synthesize`. 

For the 32k hash trace, the total time spent in synthesize halves (670 ms -> 310 ms) on my system. It's overall not a major cost now anyway but I think it'll be significant as the trace lengths improve. 

(We didn't need to modify any of circom scotia or Spartan for this.)