### PR TITLE
Cleanup dense poly

### DIFF
--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -122,7 +122,7 @@ where
     fn batch(&self) -> Self::BatchedPolynomials {
         use rayon::prelude::*;
         let (batched_dim_read, (batched_final, batched_E, batched_flag)) = rayon::join(
-            || DensePolynomial::merge(&[self.dim.as_slice(), self.read_cts.as_slice()].concat()),
+            || DensePolynomial::merge(self.dim.iter().chain(&self.read_cts)),
             || {
                 let batched_final = DensePolynomial::merge(&self.final_cts);
                 let (batched_E, batched_flag) = rayon::join(

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -122,7 +122,7 @@ where
     fn batch(&self) -> Self::BatchedPolynomials {
         use rayon::prelude::*;
         let (batched_dim_read, (batched_final, batched_E, batched_flag)) = rayon::join(
-            || DensePolynomial::merge_dual(self.dim.as_ref(), self.read_cts.as_ref()),
+            || DensePolynomial::merge(&[self.dim.as_slice(), self.read_cts.as_slice()].concat()),
             || {
                 let batched_final = DensePolynomial::merge(&self.final_cts);
                 let (batched_E, batched_flag) = rayon::join(

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -65,7 +65,7 @@ where
     #[tracing::instrument(skip_all, name = "SurgePolys::batch")]
     fn batch(&self) -> Self::BatchedPolynomials {
         let (batched_dim_read, (batched_final, batched_E)) = rayon::join(
-            || DensePolynomial::merge(&[self.dim.as_slice(), self.read_cts.as_slice()].concat()),
+            || DensePolynomial::merge(self.dim.iter().chain(&self.read_cts)),
             || {
                 rayon::join(
                     || DensePolynomial::merge(&self.final_cts),

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -65,7 +65,7 @@ where
     #[tracing::instrument(skip_all, name = "SurgePolys::batch")]
     fn batch(&self) -> Self::BatchedPolynomials {
         let (batched_dim_read, (batched_final, batched_E)) = rayon::join(
-            || DensePolynomial::merge_dual(self.dim.as_ref(), self.read_cts.as_ref()),
+            || DensePolynomial::merge(&[self.dim.as_slice(), self.read_cts.as_slice()].concat()),
             || {
                 rayon::join(
                     || DensePolynomial::merge(&self.final_cts),

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -442,16 +442,6 @@ impl<F: PrimeField> DensePolynomial<F> {
         self.Z.as_ref()
     }
 
-    pub fn extend(&mut self, other: &DensePolynomial<F>) {
-        assert_eq!(self.Z.len(), self.len);
-        let other_vec = other.vec();
-        assert_eq!(other_vec.len(), self.len);
-        self.Z.extend(other_vec);
-        self.num_vars += 1;
-        self.len *= 2;
-        assert_eq!(self.Z.len(), self.len);
-    }
-
     #[tracing::instrument(skip_all, name = "DensePoly.merge")]
     pub fn merge<T>(polys: &[T]) -> DensePolynomial<F>
     where

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -398,13 +398,14 @@ impl<F: PrimeField> DensePolynomial<F> {
     }
 
     #[tracing::instrument(skip_all, name = "DensePoly.merge")]
-    pub fn merge<T>(polys: &[T]) -> DensePolynomial<F>
-    where
-        T: AsRef<DensePolynomial<F>>,
-    {
-        let total_len: usize = polys.iter().map(|poly| poly.as_ref().vec().len()).sum();
+    pub fn merge(polys: impl IntoIterator<Item = impl AsRef<Self>> + Clone) -> DensePolynomial<F> {
+        let polys_iter_cloned = polys.clone().into_iter();
+        let total_len: usize = polys
+            .into_iter()
+            .map(|poly| poly.as_ref().vec().len())
+            .sum();
         let mut Z: Vec<F> = Vec::with_capacity(total_len.next_power_of_two());
-        for poly in polys {
+        for poly in polys_iter_cloned {
             Z.extend_from_slice(poly.as_ref().vec());
         }
 

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -469,25 +469,6 @@ impl<F: PrimeField> DensePolynomial<F> {
         DensePolynomial::new(Z)
     }
 
-    #[tracing::instrument(skip_all, name = "DensePoly.merge_dual")]
-    pub fn merge_dual<T>(polys_a: &[T], polys_b: &[T]) -> DensePolynomial<F>
-    where
-        T: AsRef<DensePolynomial<F>>,
-    {
-        let total_len_a: usize = polys_a.iter().map(|poly| poly.as_ref().len()).sum();
-        let total_len_b: usize = polys_b.iter().map(|poly| poly.as_ref().len()).sum();
-        let total_len = total_len_a + total_len_b;
-
-        let mut Z: Vec<F> = Vec::with_capacity(total_len.next_power_of_two());
-        polys_a.iter().for_each(|poly| Z.extend_from_slice(poly.as_ref().vec()));
-        polys_b.iter().for_each(|poly| Z.extend_from_slice(poly.as_ref().vec()));
-
-        // pad the polynomial with zero polynomial at the end
-        Z.resize(Z.capacity(), F::zero());
-
-        DensePolynomial::new(Z)
-    }
-
     pub fn combined_commit<G>(
         &self,
         label: &'static [u8],


### PR DESCRIPTION
Slowly preparing for [generalizing](https://github.com/a16z/Lasso/issues/8) the [PCS](https://github.com/a16z/Lasso/pull/66), which would require switching to `MultilinearExtension` from `ark-poly` and deprecating the custom `DensePolynomial` used now.

This PR should be useful regardless of whether the above happens or not:
1. Removes `merge_dual` in favor of calling `merge` on the concatenated slices
2. Removes unused `extend`
3. msm-based functionality (`flag_msm` & `sm_msm`) are not methods on `DensePolynomial` but rather stand-alone functions. Moves them to the `msm` module.