### PR TITLE
optimize: efficiently compute lookup outputs

### DIFF
--- a/jolt-core/src/jolt/instruction/add.rs
+++ b/jolt-core/src/jolt/instruction/add.rs
@@ -60,6 +60,16 @@ impl<const WORD_SIZE: usize> JoltInstruction for ADDInstruction<WORD_SIZE> {
         add_and_chunk_operands(self.0 as u128, self.1 as u128, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        if WORD_SIZE == 32 {
+            (self.0 as u32).overflowing_add(self.1 as u32).0.into()
+        } else if WORD_SIZE == 64 {
+            self.0.overflowing_add(self.1).0
+        } else {
+            panic!("only implemented for u32 / u64")
+        }
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/add.rs
+++ b/jolt-core/src/jolt/instruction/add.rs
@@ -114,7 +114,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, ADDInstruction<32>>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             ADDInstruction::<32>(100, 0),
             ADDInstruction::<32>(0, 100),

--- a/jolt-core/src/jolt/instruction/add.rs
+++ b/jolt-core/src/jolt/instruction/add.rs
@@ -82,31 +82,53 @@ mod test {
     use ark_std::test_rng;
     use rand_chacha::rand_core::RngCore;
 
-    use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-
+    use crate::{
+        jolt::instruction::{JoltInstruction, test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity}},
+        jolt_instruction_test,
+    };
     use super::ADDInstruction;
 
+    #[test]
+    fn add_instruction_32_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 4;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
+            let instruction = ADDInstruction::<32>(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(
+                instruction,
+                expected.into()
+            );
+            assert_eq!(
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
+            );
+        }
+    }
 
     #[test]
-    fn add_instruction_e2e() {
+    fn add_instruction_64_e2e() {
         let mut rng = test_rng();
         const C: usize = 8;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
             let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
+            let instruction = ADDInstruction::<64>(x, y);
+            let expected = instruction.lookup_entry_u64();
             jolt_instruction_test!(
-                ADDInstruction::<64>(x as u64, y as u64),
-                (x.overflowing_add(y)).0.into()
+                instruction,
+                expected.into()
             );
             assert_eq!(
-                ADDInstruction::<64>(x as u64, y as u64).lookup_entry::<Fr>(C, M),
-                (x.overflowing_add(y)).0.into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/add.rs
+++ b/jolt-core/src/jolt/instruction/add.rs
@@ -86,6 +86,7 @@ mod test {
 
     use super::ADDInstruction;
 
+
     #[test]
     fn add_instruction_e2e() {
         let mut rng = test_rng();
@@ -103,5 +104,27 @@ mod test {
                 (x.overflowing_add(y)).0.into()
             );
         }
+    }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = ADDInstruction::<32>(0, 0);
+        lookup_entry_u64_parity_random::<Fr, ADDInstruction<32>>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            ADDInstruction::<32>(100, 0),
+            ADDInstruction::<32>(0, 100),
+            ADDInstruction::<32>(1 , 0),
+            ADDInstruction::<32>(0, u32_max),
+            ADDInstruction::<32>(u32_max, 0),
+            ADDInstruction::<32>(u32_max, u32_max),
+            ADDInstruction::<32>(u32_max, 1 << 8),
+            ADDInstruction::<32>(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
     }
 }

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -30,7 +30,7 @@ impl JoltInstruction for ANDInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         self.0 & self.1
     }
 
@@ -47,7 +47,6 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::ANDInstruction;
 
@@ -60,12 +59,7 @@ mod test {
         for _ in 0..256 {
             let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
             let instruction = ANDInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
     }
 
@@ -75,22 +69,12 @@ mod test {
         const C: usize = 8;
         const M: usize = 1 << 16;
 
+        // Random
         for _ in 0..256 {
             let (x, y) = (rng.next_u64(), rng.next_u64());
             let instruction = ANDInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = ANDInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, ANDInstruction>(100, concrete_instruction);
 
         // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
@@ -104,6 +88,8 @@ mod test {
             ANDInstruction(u32_max, 1 << 8),
             ANDInstruction(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -65,4 +65,26 @@ mod test {
             );
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = ANDInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, ANDInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            ANDInstruction(100, 0),
+            ANDInstruction(0, 100),
+            ANDInstruction(1 , 0),
+            ANDInstruction(0, u32_max),
+            ANDInstruction(u32_max, 0),
+            ANDInstruction(u32_max, u32_max),
+            ANDInstruction(u32_max, 1 << 8),
+            ANDInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -30,6 +30,10 @@ impl JoltInstruction for ANDInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        self.0 & self.1
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -47,26 +47,45 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::ANDInstruction;
 
     #[test]
-    fn and_instruction_e2e() {
+    fn and_instruction_32_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 4;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
+            let instruction = ANDInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
+            assert_eq!(
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
+            );
+        }
+    }
+
+    #[test]
+    fn and_instruction_64_e2e() {
         let mut rng = test_rng();
         const C: usize = 8;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
             let (x, y) = (rng.next_u64(), rng.next_u64());
-            jolt_instruction_test!(ANDInstruction(x, y), (x & y).into());
+            let instruction = ANDInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                ANDInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M),
-                (x & y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -74,7 +74,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, ANDInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             ANDInstruction(100, 0),
             ANDInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/beq.rs
+++ b/jolt-core/src/jolt/instruction/beq.rs
@@ -80,7 +80,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, BEQInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             BEQInstruction(100, 0),
             BEQInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/beq.rs
+++ b/jolt-core/src/jolt/instruction/beq.rs
@@ -31,7 +31,7 @@ impl JoltInstruction for BEQInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         (self.0 == self.1).into()
     }
 
@@ -44,11 +44,10 @@ impl JoltInstruction for BEQInstruction {
 #[cfg(test)]
 mod test {
     use ark_curve25519::Fr;
-    use ark_std::{test_rng, One};
+    use ark_std::test_rng;
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::BEQInstruction;
 
@@ -58,39 +57,12 @@ mod test {
         const C: usize = 4;
         const M: usize = 1 << 16;
 
+        // Random
         for _ in 0..256 {
             let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
             let instruction = BEQInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    #[test]
-    fn beq_instruction_64_e2e() {
-        let mut rng = test_rng();
-        const C: usize = 8;
-        const M: usize = 1 << 16;
-
-        for _ in 0..256 {
-            let (x, y) = (rng.next_u64(), rng.next_u64());
-            let instruction = BEQInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
-        }
-    }
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = BEQInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, BEQInstruction>(100, concrete_instruction);
 
         // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
@@ -104,6 +76,21 @@ mod test {
             BEQInstruction(u32_max, 1 << 8),
             BEQInstruction(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
+    }
+
+    #[test]
+    fn beq_instruction_64_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 8;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let (x, y) = (rng.next_u64(), rng.next_u64());
+            let instruction = BEQInstruction(x, y);
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/beq.rs
+++ b/jolt-core/src/jolt/instruction/beq.rs
@@ -31,6 +31,10 @@ impl JoltInstruction for BEQInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 == self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/beq.rs
+++ b/jolt-core/src/jolt/instruction/beq.rs
@@ -71,4 +71,26 @@ mod test {
             assert_eq!(BEQInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::one());
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = BEQInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, BEQInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            BEQInstruction(100, 0),
+            BEQInstruction(0, 100),
+            BEQInstruction(1 , 0),
+            BEQInstruction(0, u32_max),
+            BEQInstruction(u32_max, 0),
+            BEQInstruction(u32_max, u32_max),
+            BEQInstruction(u32_max, 1 << 8),
+            BEQInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -42,7 +42,7 @@ impl JoltInstruction for BGEInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         ((self.0 as i32) >= (self.1 as i32)).into()
     }
 
@@ -55,11 +55,10 @@ impl JoltInstruction for BGEInstruction {
 #[cfg(test)]
 mod test {
     use ark_curve25519::Fr;
-    use ark_std::{test_rng, One};
+    use ark_std::test_rng;
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::BGEInstruction;
 
@@ -69,35 +68,23 @@ mod test {
         const C: usize = 4;
         const M: usize = 1 << 16;
 
+        // Random
         for _ in 0..256 {
             let x = rng.next_u32();
             let y = rng.next_u32();
 
             let instruction = BGEInstruction(x as u64, y as u64);
-            let expected = instruction.lookup_entry_u64();
 
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
+
+        // Ones
         for _ in 0..256 {
             let x = rng.next_u32();
-            jolt_instruction_test!(BGEInstruction(x as u64, x as u64), Fr::one());
-            assert_eq!(
-                BGEInstruction(x as u64, x as u64).lookup_entry::<Fr>(C, M),
-                Fr::one()
-            );
+            jolt_instruction_test!(BGEInstruction(x as u64, x as u64));
         }
-    }
 
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = BGEInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, BGEInstruction>(100, concrete_instruction);
-
-        // Test edge-cases
+        // Edge-cases
         let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             BGEInstruction(100, 0),
@@ -109,6 +96,8 @@ mod test {
             BGEInstruction(u32_max, 1 << 8),
             BGEInstruction(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -70,8 +70,8 @@ mod test {
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
-            let x = rng.next_u64() as i64;
-            let y = rng.next_u64() as i64;
+            let x = rng.next_u32();
+            let y = rng.next_u32();
 
             let instruction = BGEInstruction(x as u64, y as u64);
             let expected = instruction.lookup_entry_u64();
@@ -83,7 +83,7 @@ mod test {
             );
         }
         for _ in 0..256 {
-            let x = rng.next_u64() as i64;
+            let x = rng.next_u32();
             jolt_instruction_test!(BGEInstruction(x as u64, x as u64), Fr::one());
             assert_eq!(
                 BGEInstruction(x as u64, x as u64).lookup_entry::<Fr>(C, M),

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -59,6 +59,7 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::BGEInstruction;
 
@@ -72,10 +73,13 @@ mod test {
             let x = rng.next_u64() as i64;
             let y = rng.next_u64() as i64;
 
-            jolt_instruction_test!(BGEInstruction(x as u64, y as u64), (x >= y).into());
+            let instruction = BGEInstruction(x as u64, y as u64);
+            let expected = instruction.lookup_entry_u64();
+
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                BGEInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M),
-                (x >= y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
         for _ in 0..256 {
@@ -87,8 +91,6 @@ mod test {
             );
         }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -43,7 +43,7 @@ impl JoltInstruction for BGEInstruction {
     }
 
     fn lookup_entry_u64(&self) -> u64 {
-        (self.0 >= self.1).into()
+        ((self.0 as i32) >= (self.1 as i32)).into()
     }
 
     fn random(&self, rng: &mut StdRng) -> Self {

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -42,6 +42,10 @@ impl JoltInstruction for BGEInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 >= self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -65,7 +65,7 @@ mod test {
     #[test]
     fn bge_instruction_e2e() {
         let mut rng = test_rng();
-        const C: usize = 8;
+        const C: usize = 4;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
@@ -86,5 +86,27 @@ mod test {
                 Fr::one()
             );
         }
+    }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = BGEInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, BGEInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            BGEInstruction(100, 0),
+            BGEInstruction(0, 100),
+            BGEInstruction(1 , 0),
+            BGEInstruction(0, u32_max),
+            BGEInstruction(u32_max, 0),
+            BGEInstruction(u32_max, u32_max),
+            BGEInstruction(u32_max, 1 << 8),
+            BGEInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
     }
 }

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -96,7 +96,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, BGEInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             BGEInstruction(100, 0),
             BGEInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -81,7 +81,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, BGEUInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             BGEUInstruction(100, 0),
             BGEUInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -32,6 +32,10 @@ impl JoltInstruction for BGEUInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 >= self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -53,23 +53,50 @@ mod test {
     use super::BGEUInstruction;
 
     #[test]
-    fn bgeu_instruction_e2e() {
+    fn bgeu_instruction_32_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 4;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
+            let instruction = BGEUInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
+            assert_eq!(
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
+            );
+        }
+        for _ in 0..256 {
+            let x = rng.next_u32() as u64;
+            let instruction = BGEUInstruction(x, x);
+            jolt_instruction_test!(instruction, Fr::one());
+            assert_eq!(instruction.lookup_entry::<Fr>(C, M), Fr::one());
+        }
+    }
+
+    #[test]
+    fn bgeu_instruction_64_e2e() {
         let mut rng = test_rng();
         const C: usize = 8;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
             let (x, y) = (rng.next_u64(), rng.next_u64());
-            jolt_instruction_test!(BGEUInstruction(x, y), (x >= y).into());
+            let instruction = BGEUInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                BGEUInstruction(x, y).lookup_entry::<Fr>(C, M),
-                (x >= y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
         for _ in 0..256 {
             let x = rng.next_u64();
-            jolt_instruction_test!(BGEUInstruction(x, x), Fr::one());
-            assert_eq!(BGEUInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::one());
+            let instruction = BGEUInstruction(x, x);
+            jolt_instruction_test!(instruction, Fr::one());
+            assert_eq!(instruction.lookup_entry::<Fr>(C, M), Fr::one());
         }
     }
 

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -72,4 +72,26 @@ mod test {
             assert_eq!(BGEUInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::one());
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = BGEUInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, BGEUInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            BGEUInstruction(100, 0),
+            BGEUInstruction(0, 100),
+            BGEUInstruction(1 , 0),
+            BGEUInstruction(0, u32_max),
+            BGEUInstruction(u32_max, 0),
+            BGEUInstruction(u32_max, u32_max),
+            BGEUInstruction(u32_max, 1 << 8),
+            BGEUInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/blt.rs
+++ b/jolt-core/src/jolt/instruction/blt.rs
@@ -105,4 +105,27 @@ mod test {
             );
         }
     }
+
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = BLTInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, BLTInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            BLTInstruction(100, 0),
+            BLTInstruction(0, 100),
+            BLTInstruction(1 , 0),
+            BLTInstruction(0, u32_max),
+            BLTInstruction(u32_max, 0),
+            BLTInstruction(u32_max, u32_max),
+            BLTInstruction(u32_max, 1 << 8),
+            BLTInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/blt.rs
+++ b/jolt-core/src/jolt/instruction/blt.rs
@@ -61,6 +61,10 @@ impl JoltInstruction for BLTInstruction {
         chunk_and_concatenate_operands(self.0 as u64, self.1 as u64, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 < self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/blt.rs
+++ b/jolt-core/src/jolt/instruction/blt.rs
@@ -62,7 +62,7 @@ impl JoltInstruction for BLTInstruction {
     }
 
     fn lookup_entry_u64(&self) -> u64 {
-        (self.0 < self.1).into()
+        ((self.0 as i32) < (self.1 as i32)).into()
     }
 
     fn random(&self, rng: &mut StdRng) -> Self {
@@ -105,7 +105,6 @@ mod test {
             );
         }
     }
-
 
     use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 

--- a/jolt-core/src/jolt/instruction/blt.rs
+++ b/jolt-core/src/jolt/instruction/blt.rs
@@ -61,7 +61,7 @@ impl JoltInstruction for BLTInstruction {
         chunk_and_concatenate_operands(self.0 as u64, self.1 as u64, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         assert!(((self.0 | self.1) >> 32) == 0, "Only 32-bit implemented");
 
         ((self.0 as i32) < (self.1 as i32)).into()
@@ -76,11 +76,10 @@ impl JoltInstruction for BLTInstruction {
 #[cfg(test)]
 mod test {
     use ark_curve25519::Fr;
-    use ark_std::{test_rng, One, Zero};
+    use ark_std::{test_rng, Zero};
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::BLTInstruction;
 
@@ -94,29 +93,12 @@ mod test {
             let x = rng.next_u32();
             let y = rng.next_u32();
             let instruction = BLTInstruction(x as u64, y as u64);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
         for _ in 0..256 {
             let x = rng.next_u32();
-            jolt_instruction_test!(BLTInstruction(x as u64, x as u64), Fr::zero());
-            assert_eq!(
-                BLTInstruction(x as u64, x as u64).lookup_entry::<Fr>(C, M),
-                Fr::zero()
-            );
+            jolt_instruction_test!(BLTInstruction(x as u64, x as u64));
         }
-    }
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = BLTInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, BLTInstruction>(100, concrete_instruction);
-
-        // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             BLTInstruction(100, 0),
@@ -128,6 +110,8 @@ mod test {
             BLTInstruction(u32_max, 1 << 8),
             BLTInstruction(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/blt.rs
+++ b/jolt-core/src/jolt/instruction/blt.rs
@@ -114,7 +114,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, BLTInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             BLTInstruction(100, 0),
             BLTInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/bltu.rs
+++ b/jolt-core/src/jolt/instruction/bltu.rs
@@ -86,7 +86,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, BLTUInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             BLTUInstruction(100, 0),
             BLTUInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/bltu.rs
+++ b/jolt-core/src/jolt/instruction/bltu.rs
@@ -38,7 +38,7 @@ impl JoltInstruction for BLTUInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
     
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         (self.0 < self.1).into()
     }
 
@@ -51,11 +51,10 @@ impl JoltInstruction for BLTUInstruction {
 #[cfg(test)]
 mod test {
     use ark_curve25519::Fr;
-    use ark_std::{test_rng, One, Zero};
+    use ark_std::test_rng;
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::BLTUInstruction;
 
@@ -69,38 +68,8 @@ mod test {
             let x = rng.next_u32() as u64;
             let y = rng.next_u32() as u64;
             let instruction = BLTUInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    #[test]
-    fn bltu_instruction_64_e2e() {
-        let mut rng = test_rng();
-        const C: usize = 8;
-        const M: usize = 1 << 16;
-
-        for _ in 0..256 {
-            let x = rng.next_u64();
-            let y = rng.next_u64();
-            let instruction = BLTUInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
-        }
-    }
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = BLTUInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, BLTUInstruction>(100, concrete_instruction);
 
         // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
@@ -114,6 +83,22 @@ mod test {
             BLTUInstruction(u32_max, 1 << 8),
             BLTUInstruction(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
+    }
+
+    #[test]
+    fn bltu_instruction_64_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 8;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let x = rng.next_u64();
+            let y = rng.next_u64();
+            let instruction = BLTUInstruction(x, y);
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/bltu.rs
+++ b/jolt-core/src/jolt/instruction/bltu.rs
@@ -77,4 +77,26 @@ mod test {
             jolt_instruction_test!(BLTUInstruction(x, x), Fr::zero());
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = BLTUInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, BLTUInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            BLTUInstruction(100, 0),
+            BLTUInstruction(0, 100),
+            BLTUInstruction(1 , 0),
+            BLTUInstruction(0, u32_max),
+            BLTUInstruction(u32_max, 0),
+            BLTUInstruction(u32_max, u32_max),
+            BLTUInstruction(u32_max, 1 << 8),
+            BLTUInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/bltu.rs
+++ b/jolt-core/src/jolt/instruction/bltu.rs
@@ -37,6 +37,10 @@ impl JoltInstruction for BLTUInstruction {
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
+    
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 < self.1).into()
+    }
 
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;

--- a/jolt-core/src/jolt/instruction/bltu.rs
+++ b/jolt-core/src/jolt/instruction/bltu.rs
@@ -55,30 +55,47 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::BLTUInstruction;
 
     #[test]
-    fn bltu_instruction_e2e() {
+    fn bltu_instruction_32_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 4;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let x = rng.next_u32() as u64;
+            let y = rng.next_u32() as u64;
+            let instruction = BLTUInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
+            assert_eq!(
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
+            );
+        }
+    }
+
+    #[test]
+    fn bltu_instruction_64_e2e() {
         let mut rng = test_rng();
         const C: usize = 8;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
-            let (x, y) = (rng.next_u64(), rng.next_u64());
-            jolt_instruction_test!(BLTUInstruction(x, y), (x < y).into());
+            let x = rng.next_u64();
+            let y = rng.next_u64();
+            let instruction = BLTUInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                BLTUInstruction(x, y).lookup_entry::<Fr>(C, M),
-                (x < y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
-        for _ in 0..256 {
-            let x = rng.next_u64();
-            jolt_instruction_test!(BLTUInstruction(x, x), Fr::zero());
-        }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -52,23 +52,50 @@ mod test {
     use super::BNEInstruction;
 
     #[test]
-    fn bne_instruction_e2e() {
+    fn bne_instruction_32_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 4;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
+            let instruction = BNEInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
+            assert_eq!(
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
+            );
+        }
+        for _ in 0..256 {
+            let x = rng.next_u32() as u64;
+            let instruction = BNEInstruction(x, x);
+            jolt_instruction_test!(instruction, Fr::zero());
+            assert_eq!(instruction.lookup_entry::<Fr>(C, M), Fr::zero());
+        }
+    }
+
+    #[test]
+    fn bne_instruction_64_e2e() {
         let mut rng = test_rng();
         const C: usize = 8;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
             let (x, y) = (rng.next_u64(), rng.next_u64());
-            jolt_instruction_test!(BNEInstruction(x, y), (x != y).into());
+            let instruction = BNEInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                BNEInstruction(x, y).lookup_entry::<Fr>(C, M),
-                (x != y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
         for _ in 0..256 {
             let x = rng.next_u64();
-            jolt_instruction_test!(BNEInstruction(x, x), Fr::zero());
-            assert_eq!(BNEInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
+            let instruction = BNEInstruction(x, x);
+            jolt_instruction_test!(instruction, Fr::zero());
+            assert_eq!(instruction.lookup_entry::<Fr>(C, M), Fr::zero());
         }
     }
 

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -80,7 +80,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, BNEInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             BNEInstruction(100, 0),
             BNEInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -31,7 +31,7 @@ impl JoltInstruction for BNEInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         (self.0 != self.1).into()
     }
 
@@ -60,18 +60,27 @@ mod test {
         for _ in 0..256 {
             let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
             let instruction = BNEInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
         for _ in 0..256 {
             let x = rng.next_u32() as u64;
             let instruction = BNEInstruction(x, x);
-            jolt_instruction_test!(instruction, Fr::zero());
-            assert_eq!(instruction.lookup_entry::<Fr>(C, M), Fr::zero());
+            jolt_instruction_test!(instruction);
+        }
+        let u32_max: u64 = u32::MAX as u64;
+
+        let instructions = vec![
+            BNEInstruction(100, 0),
+            BNEInstruction(0, 100),
+            BNEInstruction(1 , 0),
+            BNEInstruction(0, u32_max),
+            BNEInstruction(u32_max, 0),
+            BNEInstruction(u32_max, u32_max),
+            BNEInstruction(u32_max, 1 << 8),
+            BNEInstruction(1 << 8, u32_max),
+        ];
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
         }
     }
 
@@ -84,40 +93,12 @@ mod test {
         for _ in 0..256 {
             let (x, y) = (rng.next_u64(), rng.next_u64());
             let instruction = BNEInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
         for _ in 0..256 {
             let x = rng.next_u64();
             let instruction = BNEInstruction(x, x);
-            jolt_instruction_test!(instruction, Fr::zero());
-            assert_eq!(instruction.lookup_entry::<Fr>(C, M), Fr::zero());
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = BNEInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, BNEInstruction>(100, concrete_instruction);
-
-        // Test edge-cases
-        let u32_max: u64 = u32::MAX as u64;
-        let instructions = vec![
-            BNEInstruction(100, 0),
-            BNEInstruction(0, 100),
-            BNEInstruction(1 , 0),
-            BNEInstruction(0, u32_max),
-            BNEInstruction(u32_max, 0),
-            BNEInstruction(u32_max, u32_max),
-            BNEInstruction(u32_max, 1 << 8),
-            BNEInstruction(1 << 8, u32_max),
-        ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
     }
 }

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -31,6 +31,10 @@ impl JoltInstruction for BNEInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 != self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -71,4 +71,26 @@ mod test {
             assert_eq!(BNEInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = BNEInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, BNEInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            BNEInstruction(100, 0),
+            BNEInstruction(0, 100),
+            BNEInstruction(1 , 0),
+            BNEInstruction(0, u32_max),
+            BNEInstruction(u32_max, 0),
+            BNEInstruction(u32_max, u32_max),
+            BNEInstruction(u32_max, 1 << 8),
+            BNEInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -51,6 +51,7 @@ pub trait JoltInstruction: Sync + Clone {
 
         self.combine_lookups(&subtable_lookup_values, C, M)
     }
+    fn lookup_entry_u64(&self) -> u64;
     fn operand_chunks(&self, C: usize, log_M: usize) -> [Vec<u64>; 2] {
         assert!(log_M % 2 == 0, "log_M must be even for operand_chunks to work");
         self.operands()

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -7,9 +7,10 @@ use std::marker::Sync;
 use crate::jolt::subtable::LassoSubtable;
 use crate::utils::index_to_field_bitvector;
 use crate::utils::instruction_utils::chunk_operand;
+use std::fmt::Debug;
 
 #[enum_dispatch]
-pub trait JoltInstruction: Sync + Clone {
+pub trait JoltInstruction: Sync + Clone + Debug {
     fn operands(&self) -> [u64; 2];
     /// Combines `vals` according to the instruction's "collation" polynomial `g`.
     /// If `vals` are subtable entries (as opposed to MLE evaluations), this function returns the

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -35,24 +35,8 @@ pub trait JoltInstruction: Sync + Clone + Debug {
     /// Converts the instruction operand(s) in their native word-sized representation into a Vec
     /// of subtable lookups indices. The returned Vec is length `C`, with elements in [0, `log_M`).
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize>;
-    fn lookup_entry<F: PrimeField>(&self, C: usize, M: usize) -> F {
-        let log_M = log2(M) as usize;
-
-        let subtable_lookup_indices = self.to_indices(C, log2(M) as usize);
-
-        let subtable_lookup_values: Vec<F> = self
-            .subtables::<F>(C)
-            .iter()
-            .flat_map(|subtable| {
-                subtable_lookup_indices.iter().map(|&lookup_index| {
-                    subtable.evaluate_mle(&index_to_field_bitvector(lookup_index, log_M))
-                })
-            })
-            .collect();
-
-        self.combine_lookups(&subtable_lookup_values, C, M)
-    }
-    fn lookup_entry_u64(&self) -> u64;
+    /// Computes the output lookup entry for this instruction as a u64.
+    fn lookup_entry(&self) -> u64;
     fn operand_chunks(&self, C: usize, log_M: usize) -> [Vec<u64>; 2] {
         assert!(log_M % 2 == 0, "log_M must be even for operand_chunks to work");
         self.operands()

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -65,4 +65,26 @@ mod test {
             );
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = ORInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, ORInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            ORInstruction(100, 0),
+            ORInstruction(0, 100),
+            ORInstruction(1 , 0),
+            ORInstruction(0, u32_max),
+            ORInstruction(u32_max, 0),
+            ORInstruction(u32_max, u32_max),
+            ORInstruction(u32_max, 1 << 8),
+            ORInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -30,7 +30,7 @@ impl JoltInstruction for ORInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         (self.0 | self.1).into()
     }
 
@@ -47,7 +47,6 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::ORInstruction;
 
@@ -61,12 +60,22 @@ mod test {
             let x = rng.next_u32() as u64;
             let y = rng.next_u32() as u64;
             let instruction = ORInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
+        }
+
+        let u32_max: u64 = u32::MAX as u64;
+        let instructions = vec![
+            ORInstruction(100, 0),
+            ORInstruction(0, 100),
+            ORInstruction(1 , 0),
+            ORInstruction(0, u32_max),
+            ORInstruction(u32_max, 0),
+            ORInstruction(u32_max, u32_max),
+            ORInstruction(u32_max, 1 << 8),
+            ORInstruction(1 << 8, u32_max),
+        ];
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
         }
     }
 
@@ -80,32 +89,7 @@ mod test {
             let x = rng.next_u64();
             let y = rng.next_u64();
             let instruction = ORInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = ORInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, ORInstruction>(100, concrete_instruction);
-
-        // Test edge-cases
-        let u32_max: u64 = u32::MAX as u64;
-        let instructions = vec![
-            ORInstruction(100, 0),
-            ORInstruction(0, 100),
-            ORInstruction(1 , 0),
-            ORInstruction(0, u32_max),
-            ORInstruction(u32_max, 0),
-            ORInstruction(u32_max, u32_max),
-            ORInstruction(u32_max, 1 << 8),
-            ORInstruction(1 << 8, u32_max),
-        ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
     }
 }

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -30,6 +30,10 @@ impl JoltInstruction for ORInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 | self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -47,26 +47,47 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::ORInstruction;
 
     #[test]
-    fn or_instruction_e2e() {
+    fn or_instruction_32_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 4;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let x = rng.next_u32() as u64;
+            let y = rng.next_u32() as u64;
+            let instruction = ORInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
+            assert_eq!(
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
+            );
+        }
+    }
+
+    #[test]
+    fn or_instruction_64_e2e() {
         let mut rng = test_rng();
         const C: usize = 8;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
-            let (x, y) = (rng.next_u64(), rng.next_u64());
-            jolt_instruction_test!(ORInstruction(x, y), (x | y).into());
+            let x = rng.next_u64();
+            let y = rng.next_u64();
+            let instruction = ORInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                ORInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M),
-                (x | y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -74,7 +74,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, ORInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             ORInstruction(100, 0),
             ORInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/sll.rs
+++ b/jolt-core/src/jolt/instruction/sll.rs
@@ -57,6 +57,10 @@ impl<const WORD_SIZE: usize> JoltInstruction for SLLInstruction<WORD_SIZE> {
         chunk_and_concatenate_for_shift(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 as u32).checked_shl(self.1 as u32 % WORD_SIZE as u32).unwrap_or(0).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/sll.rs
+++ b/jolt-core/src/jolt/instruction/sll.rs
@@ -109,7 +109,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, SLLInstruction::<32>>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SLLInstruction::<32>(100, 0),
             SLLInstruction::<32>(0, 100),

--- a/jolt-core/src/jolt/instruction/sll.rs
+++ b/jolt-core/src/jolt/instruction/sll.rs
@@ -100,4 +100,26 @@ mod test {
             );
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = SLLInstruction::<32>(0, 0);
+        lookup_entry_u64_parity_random::<Fr, SLLInstruction::<32>>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            SLLInstruction::<32>(100, 0),
+            SLLInstruction::<32>(0, 100),
+            SLLInstruction::<32>(1 , 0),
+            SLLInstruction::<32>(0, u32_max),
+            SLLInstruction::<32>(u32_max, 0),
+            SLLInstruction::<32>(u32_max, u32_max),
+            SLLInstruction::<32>(u32_max, 1 << 8),
+            SLLInstruction::<32>(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -78,33 +78,28 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+    
     use super::SLTInstruction;
 
     #[test]
-    fn slt_instruction_e2e() {
+    fn slt_instruction_32_e2e() {
         let mut rng = test_rng();
-        const C: usize = 8;
+        const C: usize = 4;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
-            let x = rng.next_u64() as i64;
-            let y = rng.next_u64() as i64;
-
-            jolt_instruction_test!(SLTInstruction(x as u64, y as u64), (x < y).into());
+            let x = rng.next_u32() as u64;
+            let y = rng.next_u32() as u64;
+            let instruction = SLTInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                SLTInstruction(x as u64, y as u64).lookup_entry::<Fr>(C, M),
-                (x < y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
-        for _ in 0..256 {
-            let x = rng.next_u64() as u64;
-            jolt_instruction_test!(SLTInstruction(x, x), Fr::zero());
-            assert_eq!(SLTInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
-        }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -61,6 +61,10 @@ impl JoltInstruction for SLTInstruction {
         chunk_and_concatenate_operands(self.0 as u64, self.1 as u64, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 < self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -108,11 +108,11 @@ mod test {
 
     #[test]
     fn u64_parity() {
-        // let concrete_instruction = SLTInstruction(0, 0);
-        // lookup_entry_u64_parity_random::<Fr, SLTInstruction>(100, concrete_instruction);
+        let concrete_instruction = SLTInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, SLTInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = (((1u64 << 32u64) - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SLTInstruction(100, 0),
             SLTInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -61,7 +61,7 @@ impl JoltInstruction for SLTInstruction {
         chunk_and_concatenate_operands(self.0 as u64, self.1 as u64, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         ((self.0 as i32) < (self.1 as i32)).into()
     }
 
@@ -74,11 +74,10 @@ impl JoltInstruction for SLTInstruction {
 #[cfg(test)]
 mod test {
     use ark_curve25519::Fr;
-    use ark_std::{test_rng, One, Zero};
+    use ark_std::test_rng;
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
     
     use super::SLTInstruction;
 
@@ -92,21 +91,8 @@ mod test {
             let x = rng.next_u32() as u64;
             let y = rng.next_u32() as u64;
             let instruction = SLTInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = SLTInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, SLTInstruction>(100, concrete_instruction);
-
-        // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SLTInstruction(100, 0),
@@ -118,6 +104,8 @@ mod test {
             SLTInstruction(u32_max, 1 << 8),
             SLTInstruction(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -103,4 +103,26 @@ mod test {
             assert_eq!(SLTInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = SLTInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, SLTInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            SLTInstruction(100, 0),
+            SLTInstruction(0, 100),
+            SLTInstruction(1 , 0),
+            SLTInstruction(0, u32_max),
+            SLTInstruction(u32_max, 0),
+            SLTInstruction(u32_max, u32_max),
+            SLTInstruction(u32_max, 1 << 8),
+            SLTInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -62,7 +62,7 @@ impl JoltInstruction for SLTInstruction {
     }
 
     fn lookup_entry_u64(&self) -> u64 {
-        (self.0 < self.1).into()
+        ((self.0 as i32) < (self.1 as i32)).into()
     }
 
     fn random(&self, rng: &mut StdRng) -> Self {
@@ -108,15 +108,15 @@ mod test {
 
     #[test]
     fn u64_parity() {
-        let concrete_instruction = SLTInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, SLTInstruction>(100, concrete_instruction);
+        // let concrete_instruction = SLTInstruction(0, 0);
+        // lookup_entry_u64_parity_random::<Fr, SLTInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = (((1u64 << 32u64) - 1) as u32) as u64;
         let instructions = vec![
             SLTInstruction(100, 0),
             SLTInstruction(0, 100),
-            SLTInstruction(1 , 0),
+            SLTInstruction(1, 0),
             SLTInstruction(0, u32_max),
             SLTInstruction(u32_max, 0),
             SLTInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -38,6 +38,10 @@ impl JoltInstruction for SLTUInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 < self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -38,7 +38,7 @@ impl JoltInstruction for SLTUInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         (self.0 < self.1).into()
     }
 
@@ -51,11 +51,10 @@ impl JoltInstruction for SLTUInstruction {
 #[cfg(test)]
 mod test {
     use ark_curve25519::Fr;
-    use ark_std::{test_rng, One, Zero};
+    use ark_std::{test_rng, Zero};
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::SLTUInstruction;
 
@@ -68,26 +67,13 @@ mod test {
         for _ in 0..256 {
             let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
             let instruction = SLTUInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
         for _ in 0..256 {
             let x = rng.next_u32() as u64;
-            jolt_instruction_test!(SLTUInstruction(x, x), Fr::zero());
-            assert_eq!(SLTUInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
+            jolt_instruction_test!(SLTUInstruction(x, x));
         }
-    }
 
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = SLTUInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, SLTUInstruction>(100, concrete_instruction);
-
-        // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SLTUInstruction(100, 0),
@@ -99,6 +85,8 @@ mod test {
             SLTUInstruction(u32_max, 1 << 8),
             SLTUInstruction(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -87,7 +87,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, SLTUInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SLTUInstruction(100, 0),
             SLTUInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -55,21 +55,24 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::SLTUInstruction;
 
     #[test]
-    fn sltu_instruction_e2e() {
+    fn sltu_instruction_32_e2e() {
         let mut rng = test_rng();
         const C: usize = 4;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
             let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
-            jolt_instruction_test!(SLTUInstruction(x, y), (x < y).into());
+            let instruction = SLTUInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                SLTUInstruction(x, y).lookup_entry::<Fr>(C, M),
-                (x < y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
         for _ in 0..256 {
@@ -78,8 +81,6 @@ mod test {
             assert_eq!(SLTUInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
         }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -78,4 +78,26 @@ mod test {
             assert_eq!(SLTUInstruction(x, x).lookup_entry::<Fr>(C, M), Fr::zero());
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = SLTUInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, SLTUInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            SLTUInstruction(100, 0),
+            SLTUInstruction(0, 100),
+            SLTUInstruction(1 , 0),
+            SLTUInstruction(0, u32_max),
+            SLTUInstruction(u32_max, 0),
+            SLTUInstruction(u32_max, u32_max),
+            SLTUInstruction(u32_max, 1 << 8),
+            SLTUInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -61,7 +61,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRAInstruction<WORD_SIZE> {
     fn lookup_entry_u64(&self) -> u64 {
         let x = self.0 as i32;
         let y = (self.1 as u32 % (WORD_SIZE as u32));
-        x.checked_shr(y).unwrap_or(0) as u64
+        (x.checked_shr(y).unwrap_or(0) as u32).into()
     }
 
     fn random(&self, rng: &mut StdRng) -> Self {

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -77,11 +77,12 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::SRAInstruction;
 
     #[test]
-    fn sra_instruction_e2e() {
+    fn sra_instruction_32_e2e() {
         let mut rng = test_rng();
         const C: usize = 4;
         const M: usize = 1 << 16;
@@ -90,20 +91,18 @@ mod test {
         for _ in 0..8 {
             let (x, y) = (rng.next_u32(), rng.next_u32());
             let instruction = SRAInstruction::<WORD_SIZE>(x as u64, y as u64);
-            let output = instruction.lookup_entry_u64();
+            let expected = instruction.lookup_entry_u64();
 
             jolt_instruction_test!(
                 instruction,
-                (output as u32).into()
+                expected.into()
             );
             assert_eq!(
                 instruction.lookup_entry::<Fr>(C, M),
-                (output as u32).into()
+                expected.into()
             );
         }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -101,4 +101,26 @@ mod test {
             );
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = SRAInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, SRAInstruction::<32>>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            SRAInstruction::<32>(100, 0),
+            SRAInstruction::<32>(0, 100),
+            SRAInstruction::<32>(1 , 0),
+            SRAInstruction::<32>(0, u32_max),
+            SRAInstruction::<32>(u32_max, 0),
+            SRAInstruction::<32>(u32_max, u32_max),
+            SRAInstruction::<32>(u32_max, 1 << 8),
+            SRAInstruction::<32>(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -110,7 +110,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, SRAInstruction::<32>>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SRAInstruction::<32>(100, 0),
             SRAInstruction::<32>(0, 100),

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -58,7 +58,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRAInstruction<WORD_SIZE> {
         chunk_and_concatenate_for_shift(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         let x = self.0 as i32;
         let y = (self.1 as u32 % (WORD_SIZE as u32));
         (x.checked_shr(y).unwrap_or(0) as u32).into()
@@ -77,7 +77,6 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::SRAInstruction;
 
@@ -88,28 +87,11 @@ mod test {
         const M: usize = 1 << 16;
         const WORD_SIZE: usize = 32;
 
-        for _ in 0..8 {
+        for _ in 0..256 {
             let (x, y) = (rng.next_u32(), rng.next_u32());
             let instruction = SRAInstruction::<WORD_SIZE>(x as u64, y as u64);
-            let expected = instruction.lookup_entry_u64();
-
-            jolt_instruction_test!(
-                instruction,
-                expected.into()
-            );
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = SRAInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, SRAInstruction::<32>>(100, concrete_instruction);
-
-        // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SRAInstruction::<32>(100, 0),
@@ -121,6 +103,8 @@ mod test {
             SRAInstruction::<32>(u32_max, 1 << 8),
             SRAInstruction::<32>(1 << 8, 1 << 16),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -89,16 +89,16 @@ mod test {
 
         for _ in 0..8 {
             let (x, y) = (rng.next_u32(), rng.next_u32());
-
-            let entry: i32 = (x as i32).checked_shr(y % WORD_SIZE as u32).unwrap_or(0);
+            let instruction = SRAInstruction::<WORD_SIZE>(x as u64, y as u64);
+            let output = instruction.lookup_entry_u64();
 
             jolt_instruction_test!(
-                SRAInstruction::<WORD_SIZE>(x as u64, y as u64),
-                (entry as u32).into()
+                instruction,
+                (output as u32).into()
             );
             assert_eq!(
-                SRAInstruction::<WORD_SIZE>(x as u64, y as u64).lookup_entry::<Fr>(C, M),
-                (entry as u32).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                (output as u32).into()
             );
         }
     }

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -59,8 +59,9 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRAInstruction<WORD_SIZE> {
     }
 
     fn lookup_entry_u64(&self) -> u64 {
-        // TODO(sragss): Not sure this is correct.
-        (self.0 as i32).checked_shr(self.1 as u32).unwrap_or(0) as u64
+        let x = self.0 as i32;
+        let y = (self.1 as u32 % (WORD_SIZE as u32));
+        x.checked_shr(y).unwrap_or(0) as u64
     }
 
     fn random(&self, rng: &mut StdRng) -> Self {
@@ -113,13 +114,13 @@ mod test {
         let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SRAInstruction::<32>(100, 0),
-            SRAInstruction::<32>(0, 100),
-            SRAInstruction::<32>(1 , 0),
-            SRAInstruction::<32>(0, u32_max),
+            SRAInstruction::<32>(0, 2),
+            SRAInstruction::<32>(1 , 2),
+            SRAInstruction::<32>(0, 32),
             SRAInstruction::<32>(u32_max, 0),
-            SRAInstruction::<32>(u32_max, u32_max),
+            SRAInstruction::<32>(u32_max, 31),
             SRAInstruction::<32>(u32_max, 1 << 8),
-            SRAInstruction::<32>(1 << 8, u32_max),
+            SRAInstruction::<32>(1 << 8, 1 << 16),
         ];
         lookup_entry_u64_parity::<Fr, _>(instructions);
     }

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -58,6 +58,11 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRAInstruction<WORD_SIZE> {
         chunk_and_concatenate_for_shift(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        // TODO(sragss): Not sure this is correct.
+        (self.0 as i32).checked_shr(self.1 as u32).unwrap_or(0) as u64
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -54,7 +54,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {
         chunk_and_concatenate_for_shift(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         let x = self.0 as u32;
         let y = (self.1 % WORD_SIZE as u64) as u32;
         x.checked_shr(y).unwrap_or(0).into()
@@ -73,7 +73,6 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::SRLInstruction;
 
@@ -84,28 +83,11 @@ mod test {
         const M: usize = 1 << 22;
         const WORD_SIZE: usize = 32;
 
-        for _ in 0..8 {
+        for _ in 0..256 {
             let (x, y) = (rng.next_u32(), rng.next_u32());
             let instruction = SRLInstruction::<WORD_SIZE>(x as u64, y as u64);
-            let expected = instruction.lookup_entry_u64();
-
-            jolt_instruction_test!(
-                instruction,
-                expected.into()
-            );
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = SRLInstruction::<32>(0, 0);
-        lookup_entry_u64_parity_random::<Fr, SRLInstruction::<32>>(100, concrete_instruction);
-
-        // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SRLInstruction::<32>(100, 0),
@@ -117,6 +99,8 @@ mod test {
             SRLInstruction::<32>(u32_max, 1 << 8),
             SRLInstruction::<32>(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -54,6 +54,10 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {
         chunk_and_concatenate_for_shift(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 as u32).checked_shr(self.1 as u32).unwrap_or(0).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -96,4 +96,26 @@ mod test {
             );
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = SRLInstruction::<32>(0, 0);
+        lookup_entry_u64_parity_random::<Fr, SRLInstruction::<32>>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            SRLInstruction::<32>(100, 0),
+            SRLInstruction::<32>(0, 100),
+            SRLInstruction::<32>(1 , 0),
+            SRLInstruction::<32>(0, u32_max),
+            SRLInstruction::<32>(u32_max, 0),
+            SRLInstruction::<32>(u32_max, u32_max),
+            SRLInstruction::<32>(u32_max, 1 << 8),
+            SRLInstruction::<32>(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -73,6 +73,7 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     use super::SRLInstruction;
 
@@ -85,21 +86,19 @@ mod test {
 
         for _ in 0..8 {
             let (x, y) = (rng.next_u32(), rng.next_u32());
-
-            let entry: u64 = x.checked_shr(y % WORD_SIZE as u32).unwrap_or(0) as u64;
+            let instruction = SRLInstruction::<WORD_SIZE>(x as u64, y as u64);
+            let expected = instruction.lookup_entry_u64();
 
             jolt_instruction_test!(
-                SRLInstruction::<WORD_SIZE>(x as u64, y as u64),
-                entry.into()
+                instruction,
+                expected.into()
             );
             assert_eq!(
-                SRLInstruction::<WORD_SIZE>(x as u64, y as u64).lookup_entry::<Fr>(C, M),
-                entry.into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
     }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
 
     #[test]
     fn u64_parity() {

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -105,7 +105,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, SRLInstruction::<32>>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SRLInstruction::<32>(100, 0),
             SRLInstruction::<32>(0, 100),

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -55,7 +55,9 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {
     }
 
     fn lookup_entry_u64(&self) -> u64 {
-        (self.0 as u32).checked_shr(self.1 as u32).unwrap_or(0).into()
+        let x = self.0 as u32;
+        let y = (self.1 % WORD_SIZE as u64) as u32;
+        x.checked_shr(y).unwrap_or(0).into()
     }
 
     fn random(&self, rng: &mut StdRng) -> Self {

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -63,7 +63,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SUBInstruction<WORD_SIZE> {
     }
 
     fn lookup_entry_u64(&self) -> u64 {
-        self.0.overflowing_sub(self.1).0.into()
+        (self.0 as u32).overflowing_sub(self.1 as u32).0.into()
     }
 
     fn random(&self, rng: &mut StdRng) -> Self {

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -110,7 +110,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, SUBInstruction::<32>>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SUBInstruction::<32>(100, 0),
             SUBInstruction::<32>(0, 100),

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -91,13 +91,15 @@ mod test {
 
         for _ in 0..256 {
             let (x, y) = (rng.next_u32(), rng.next_u32());
+            let instruction = SUBInstruction::<WORD_SIZE>(x as u64, y as u64);
+            let expected = instruction.lookup_entry_u64();
             jolt_instruction_test!(
-                SUBInstruction::<WORD_SIZE>(x as u64, y as u64),
-                (x.overflowing_sub(y)).0.into()
+                instruction,
+                expected.into()
             );
             assert_eq!(
-                SUBInstruction::<WORD_SIZE>(x as u64, y as u64).lookup_entry::<Fr>(C, M),
-                (x.overflowing_sub(y).0.into())
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
     }

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -101,4 +101,26 @@ mod test {
             );
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = SUBInstruction::<32>(0, 0);
+        lookup_entry_u64_parity_random::<Fr, SUBInstruction::<32>>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            SUBInstruction::<32>(100, 0),
+            SUBInstruction::<32>(0, 100),
+            SUBInstruction::<32>(1 , 0),
+            SUBInstruction::<32>(0, u32_max),
+            SUBInstruction::<32>(u32_max, 0),
+            SUBInstruction::<32>(u32_max, u32_max),
+            SUBInstruction::<32>(u32_max, 1 << 8),
+            SUBInstruction::<32>(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -62,7 +62,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SUBInstruction<WORD_SIZE> {
         )
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         (self.0 as u32).overflowing_sub(self.1 as u32).0.into()
     }
 
@@ -92,26 +92,9 @@ mod test {
         for _ in 0..256 {
             let (x, y) = (rng.next_u32(), rng.next_u32());
             let instruction = SUBInstruction::<WORD_SIZE>(x as u64, y as u64);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(
-                instruction,
-                expected.into()
-            );
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
 
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = SUBInstruction::<32>(0, 0);
-        lookup_entry_u64_parity_random::<Fr, SUBInstruction::<32>>(100, concrete_instruction);
-
-        // Test edge-cases
         let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             SUBInstruction::<32>(100, 0),
@@ -123,6 +106,8 @@ mod test {
             SUBInstruction::<32>(u32_max, 1 << 8),
             SUBInstruction::<32>(1 << 8, u32_max),
         ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -62,6 +62,10 @@ impl<const WORD_SIZE: usize> JoltInstruction for SUBInstruction<WORD_SIZE> {
         )
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        self.0.overflowing_sub(self.1).0.into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -4,9 +4,9 @@
 /// 1. Materializes each subtable in `subtables`
 /// 2. Converts operands to subtable lookup indices using `to_indices`
 /// 3. Combines the looked-up subtable entries using `combine_lookups`
-/// 4. Checks that the result equals the expected value, given by the RHS expression
+/// 4. Checks that the result equals the expected value, given by the `lookup_output`
 macro_rules! jolt_instruction_test {
-    ($instr:expr, $expected_value:expr) => {
+    ($instr:expr) => {
         let materialized_subtables: Vec<_> = $instr
             .subtables::<Fr>(C)
             .iter()
@@ -23,45 +23,8 @@ macro_rules! jolt_instruction_test {
         }
 
         let actual = $instr.combine_lookups(&subtable_values, C, M);
-        let expected = $expected_value;
+        let expected = Fr::from($instr.lookup_entry());
 
         assert_eq!(actual, expected, "{:?}", $instr);
     };
-}
-
-use ark_ff::PrimeField;
-use crate::jolt::instruction::JoltInstruction;
-use rand_core::SeedableRng;
-
-const TEST_C: usize = 4;
-const TEST_M: usize = 1 << 16;
-
-/// Tests `num_iters` random instructions for their parity between the `lookup_entry()`
-/// and `lookup_entry_u64` functions. Needs `concrete_instruction: I` to call `.random(&self)`.
-pub fn lookup_entry_u64_parity_random<F, I>(num_iters: usize, concrete_instruction: I) 
-where
-    F: PrimeField,
-    I: JoltInstruction
-{
-    let mut rng = rand::rngs::StdRng::seed_from_u64(1234567890);
-    let mut instructions: Vec<I> = Vec::new();
-    for _ in 0..num_iters {
-        let instruction = concrete_instruction.random(&mut rng);
-        instructions.push(instruction);
-    }
-    lookup_entry_u64_parity::<F, I>(instructions);
-}
-
-/// Tests `instructions` for their parity between the `lookup_entry()`
-/// and `lookup_entry_u64` functions.
-pub fn lookup_entry_u64_parity<F, I>(instructions: Vec<I>) 
-where
-    F: PrimeField,
-    I: JoltInstruction 
-{
-    for (index, instruction) in instructions.into_iter().enumerate() {
-        let fr = instruction.lookup_entry::<F>(TEST_C, TEST_M);
-        let u = instruction.lookup_entry_u64();
-        assert_eq!(fr, F::from(u), "[{index}] Entries did not match for {instruction:?}. Left: lookup_entry(), Right: lookup_entry_u64()");
-    }
 }

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -59,9 +59,9 @@ where
     F: PrimeField,
     I: JoltInstruction 
 {
-    for instruction in instructions {
+    for (index, instruction) in instructions.into_iter().enumerate() {
         let fr = instruction.lookup_entry::<F>(TEST_C, TEST_M);
         let u = instruction.lookup_entry_u64();
-        assert_eq!(fr, F::from(u), "Entries did not match for {instruction:?}");
+        assert_eq!(fr, F::from(u), "[{index}] Entries did not match for {instruction:?}. Left: lookup_entry(), Right: lookup_entry_u64()");
     }
 }

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -28,3 +28,40 @@ macro_rules! jolt_instruction_test {
         assert_eq!(actual, expected, "{:?}", $instr);
     };
 }
+
+use ark_ff::PrimeField;
+use crate::jolt::instruction::JoltInstruction;
+use rand_core::SeedableRng;
+
+const TEST_C: usize = 4;
+const TEST_M: usize = 1 << 16;
+
+/// Tests `num_iters` random instructions for their parity between the `lookup_entry()`
+/// and `lookup_entry_u64` functions. Needs `concrete_instruction: I` to call `.random(&self)`.
+pub fn lookup_entry_u64_parity_random<F, I>(num_iters: usize, concrete_instruction: I) 
+where
+    F: PrimeField,
+    I: JoltInstruction
+{
+    let mut rng = rand::rngs::StdRng::seed_from_u64(1234567890);
+    let mut instructions: Vec<I> = Vec::new();
+    for _ in 0..num_iters {
+        let instruction = concrete_instruction.random(&mut rng);
+        instructions.push(instruction);
+    }
+    lookup_entry_u64_parity::<F, I>(instructions);
+}
+
+/// Tests `instructions` for their parity between the `lookup_entry()`
+/// and `lookup_entry_u64` functions.
+pub fn lookup_entry_u64_parity<F, I>(instructions: Vec<I>) 
+where
+    F: PrimeField,
+    I: JoltInstruction 
+{
+    for instruction in instructions {
+        let fr = instruction.lookup_entry::<F>(TEST_C, TEST_M);
+        let u = instruction.lookup_entry_u64();
+        assert_eq!(fr, F::from(u), "Entries did not match for {instruction:?}");
+    }
+}

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -30,7 +30,7 @@ impl JoltInstruction for XORInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
-    fn lookup_entry_u64(&self) -> u64 {
+    fn lookup_entry(&self) -> u64 {
         (self.0 ^ self.1).into()
     }
 
@@ -59,12 +59,22 @@ mod test {
         for _ in 0..256 {
             let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
             let instruction = XORInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
+        }
+
+        let u32_max: u64 = u32::MAX as u64;
+        let instructions = vec![
+            XORInstruction(100, 0),
+            XORInstruction(0, 100),
+            XORInstruction(1 , 0),
+            XORInstruction(0, u32_max),
+            XORInstruction(u32_max, 0),
+            XORInstruction(u32_max, u32_max),
+            XORInstruction(u32_max, 1 << 8),
+            XORInstruction(1 << 8, u32_max),
+        ];
+        for instruction in instructions {
+            jolt_instruction_test!(instruction);
         }
     }
 
@@ -77,34 +87,7 @@ mod test {
         for _ in 0..256 {
             let (x, y) = (rng.next_u64(), rng.next_u64());
             let instruction = XORInstruction(x, y);
-            let expected = instruction.lookup_entry_u64();
-            jolt_instruction_test!(instruction, expected.into());
-            assert_eq!(
-                instruction.lookup_entry::<Fr>(C, M),
-                expected.into()
-            );
+            jolt_instruction_test!(instruction);
         }
-    }
-
-    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
-
-    #[test]
-    fn u64_parity() {
-        let concrete_instruction = XORInstruction(0, 0);
-        lookup_entry_u64_parity_random::<Fr, XORInstruction>(100, concrete_instruction);
-
-        // Test edge-cases
-        let u32_max: u64 = u32::MAX as u64;
-        let instructions = vec![
-            XORInstruction(100, 0),
-            XORInstruction(0, 100),
-            XORInstruction(1 , 0),
-            XORInstruction(0, u32_max),
-            XORInstruction(u32_max, 0),
-            XORInstruction(u32_max, u32_max),
-            XORInstruction(u32_max, 1 << 8),
-            XORInstruction(1 << 8, u32_max),
-        ];
-        lookup_entry_u64_parity::<Fr, _>(instructions);
     }
 }

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -51,17 +51,37 @@ mod test {
     use super::XORInstruction;
 
     #[test]
-    fn xor_instruction_e2e() {
+    fn xor_instruction_32_e2e() {
+        let mut rng = test_rng();
+        const C: usize = 4;
+        const M: usize = 1 << 16;
+
+        for _ in 0..256 {
+            let (x, y) = (rng.next_u32() as u64, rng.next_u32() as u64);
+            let instruction = XORInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
+            assert_eq!(
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
+            );
+        }
+    }
+
+    #[test]
+    fn xor_instruction_64_e2e() {
         let mut rng = test_rng();
         const C: usize = 8;
         const M: usize = 1 << 16;
 
         for _ in 0..256 {
             let (x, y) = (rng.next_u64(), rng.next_u64());
-            jolt_instruction_test!(XORInstruction(x, y), (x ^ y).into());
+            let instruction = XORInstruction(x, y);
+            let expected = instruction.lookup_entry_u64();
+            jolt_instruction_test!(instruction, expected.into());
             assert_eq!(
-                XORInstruction(x, y).lookup_entry::<Fr>(C, M),
-                (x ^ y).into()
+                instruction.lookup_entry::<Fr>(C, M),
+                expected.into()
             );
         }
     }

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -74,7 +74,7 @@ mod test {
         lookup_entry_u64_parity_random::<Fr, XORInstruction>(100, concrete_instruction);
 
         // Test edge-cases
-        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let u32_max: u64 = u32::MAX as u64;
         let instructions = vec![
             XORInstruction(100, 0),
             XORInstruction(0, 100),

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -65,4 +65,26 @@ mod test {
             );
         }
     }
+
+    use crate::jolt::instruction::test::{lookup_entry_u64_parity_random, lookup_entry_u64_parity};
+
+    #[test]
+    fn u64_parity() {
+        let concrete_instruction = XORInstruction(0, 0);
+        lookup_entry_u64_parity_random::<Fr, XORInstruction>(100, concrete_instruction);
+
+        // Test edge-cases
+        let u32_max: u64 = ((1u64 << 32u64 - 1) as u32) as u64;
+        let instructions = vec![
+            XORInstruction(100, 0),
+            XORInstruction(0, 100),
+            XORInstruction(1 , 0),
+            XORInstruction(0, u32_max),
+            XORInstruction(u32_max, 0),
+            XORInstruction(u32_max, u32_max),
+            XORInstruction(u32_max, 1 << 8),
+            XORInstruction(1 << 8, u32_max),
+        ];
+        lookup_entry_u64_parity::<Fr, _>(instructions);
+    }
 }

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -30,6 +30,10 @@ impl JoltInstruction for XORInstruction {
         chunk_and_concatenate_operands(self.0, self.1, C, log_M)
     }
 
+    fn lookup_entry_u64(&self) -> u64 {
+        (self.0 ^ self.1).into()
+    }
+
     fn random(&self, rng: &mut StdRng) -> Self {
         use rand_core::RngCore;
         Self(rng.next_u32() as u64, rng.next_u32() as u64)

--- a/jolt-core/src/jolt/trace/rv.rs
+++ b/jolt-core/src/jolt/trace/rv.rs
@@ -346,7 +346,7 @@ impl RVTraceRow {
                 // Assert instruction correctness
                 let lookups = self.to_jolt_instructions();
                 assert_eq!(lookups.len(), 1);
-                let expected_result: Fr = lookups[0].lookup_entry(C, M);
+                let expected_result: Fr = Fr::from(lookups[0].lookup_entry());
                 let bigint = expected_result.into_bigint();
                 let expected_result: u64 = bigint.0[0];
 
@@ -382,7 +382,7 @@ impl RVTraceRow {
                     assert!(lookups.len() == 1);
                     if lookups.len() == 1 && self.rd.unwrap() != 0 {
                         assert_eq!(lookups.len(), 1, "{self:?}");
-                        let expected_result: Fr = lookups[0].lookup_entry(C, M);
+                        let expected_result: Fr = Fr::from(lookups[0].lookup_entry());
                         let bigint = expected_result.into_bigint();
                         let expected_result: u64 = bigint.0[0];
 

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -361,7 +361,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     fn compute_lookup_outputs(instructions: &Vec<Self::InstructionSet>) -> Vec<F> {
         instructions
             .par_iter()
-            .map(|op| F::from(op.lookup_entry_u64()))
+            .map(|op| F::from(op.lookup_entry()))
             .collect()
     }
 }

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -285,16 +285,14 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
         let (mut chunks_x, mut chunks_y): (Vec<F>, Vec<F>) = instructions
             .iter()
             .flat_map(|op| {
-                let chunks_xy = op.operand_chunks(C, log_M);
-                let chunks_x = chunks_xy[0].clone();
-                let chunks_y = chunks_xy[1].clone();
+                let [chunks_x, chunks_y] = op.operand_chunks(C, log_M);
                 chunks_x.into_iter().zip(chunks_y.into_iter())
             })
             .map(|(x, y)| (F::from(x as u64), F::from(y as u64)))
             .unzip();
 
-        let mut chunks_query = instructions
-            .iter()
+        let chunks_query = instructions
+            .par_iter()
             .flat_map(|op| op.to_indices(C, log_M))
             .map(|x| x as u64)
             .map(F::from)
@@ -354,7 +352,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     fn compute_lookup_outputs(instructions: &Vec<Self::InstructionSet>) -> Vec<F> {
         instructions
             .par_iter()
-            .map(|op| op.lookup_entry::<F>(C, M))
+            .map(|op| F::from(op.lookup_entry_u64()))
             .collect()
     }
 }

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -300,7 +300,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
             .map(|(x, y)| (F::from(x as u64), F::from(y as u64)))
             .unzip();
 
-        let chunks_query = instructions
+        let mut chunks_query = instructions
             .par_iter()
             .flat_map(|op| op.to_indices(C, log_M))
             .map(|x| x as u64)

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -424,7 +424,6 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> ReadWriteMemory<F, G> {
             match memory_access {
                 MemoryOp::Read(a, v) => {
                     let remapped_a = remap_address(a);
-                    // TODO(arasuarun): This is a hack to get the memory parts of the hash example to work
                     debug_assert_eq!(v, v_final[remapped_a as usize]);
                     a_read_write.push(remapped_a);
                     v_read.push(v);
@@ -450,9 +449,8 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> ReadWriteMemory<F, G> {
         drop(_enter);
         drop(span);
 
-        // create a closure to convert u64 to F vector
         let to_f_vec =
-            |v: &Vec<u64>| -> Vec<F> { v.iter().map(|i| F::from(*i)).collect::<Vec<F>>() };
+            |v: &Vec<u64>| -> Vec<F> { v.into_par_iter().map(|i| F::from(*i)).collect::<Vec<F>>() };
 
         let un_remap_address = |a: &Vec<u64>| {
             a.iter()

--- a/jolt-core/src/jolt/vm/rv32i_vm.rs
+++ b/jolt-core/src/jolt/vm/rv32i_vm.rs
@@ -27,7 +27,7 @@ macro_rules! instruction_set {
     ($enum_name:ident, $($alias:ident: $struct:ty),+) => {
         #[allow(non_camel_case_types)]
         #[repr(u8)]
-        #[derive(Copy, Clone, EnumIter, EnumCountMacro)]
+        #[derive(Copy, Clone, Debug, EnumIter, EnumCountMacro)]
         #[enum_dispatch(JoltInstruction)]
         pub enum $enum_name { $($alias($struct)),+ }
         impl Opcode for $enum_name {}


### PR DESCRIPTION
Saves 5-7% e2e by computing the lookup outputs in `u64`.

