### PR TITLE
optimize: RangeCheckPolynomials::construct

### DIFF
--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -134,25 +134,25 @@ where
             .collect();
 
         let read_cts_read_timestamp = read_and_final_cts
-            .iter()
+            .par_iter()
             .map(|cts| DensePolynomial::from_u64(&cts[0]))
             .collect::<Vec<DensePolynomial<F>>>()
             .try_into()
             .unwrap();
         let read_cts_global_minus_read = read_and_final_cts
-            .iter()
+            .par_iter()
             .map(|cts| DensePolynomial::from_u64(&cts[1]))
             .collect::<Vec<DensePolynomial<F>>>()
             .try_into()
             .unwrap();
         let final_cts_read_timestamp = read_and_final_cts
-            .iter()
+            .par_iter()
             .map(|cts| DensePolynomial::from_u64(&cts[2]))
             .collect::<Vec<DensePolynomial<F>>>()
             .try_into()
             .unwrap();
         let final_cts_global_minus_read = read_and_final_cts
-            .iter()
+            .par_iter()
             .map(|cts| DensePolynomial::from_u64(&cts[3]))
             .collect::<Vec<DensePolynomial<F>>>()
             .try_into()


### PR DESCRIPTION
These take 95%+ of the function. Speeds it up by roughly `num_threads / 2`. Slowness is due to the fact that each `F::from` does a field multiplication. 

We can theoretically make this faster with the table method: Precompute a table in the range say [0..1 << 10] then construct the `DensePolynomial<F>` from the table. This would skip the field multiplication in most cases. For a 512k trace this takes a few bips of time so likely not worth the complexity.