### PR TITLE
feat: Speed up JoltCircuit::synthesize

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,6 @@ ark-ff = "0.4.2"
 ark-std = "0.4.0"
 bellpepper-core = "0.4.0"
 ff = "0.13.0"
-spartan2 = "0.1.0"
+spartan2 = { git = "https://github.com/a16z/Spartan2"}
 ruint = "1.11.1"
+halo2curves = "0.6.0"

--- a/common/src/field_conversion.rs
+++ b/common/src/field_conversion.rs
@@ -2,6 +2,7 @@ use ark_bn254::Fr as ArkFr;
 use ark_ff::{fields::PrimeField as ArkPrimeField, BigInteger};
 
 use ff::PrimeField as GenericPrimeField;
+use halo2curves::serde::SerdeObject;
 use spartan2::provider::bn256_grumpkin::bn256::Scalar as Spartan2Fr;
 
 pub fn ark_to_spartan<ArkF: ArkPrimeField>(ark: ArkF) -> Spartan2Fr {
@@ -48,6 +49,36 @@ pub fn ff_to_ruints<FF: GenericPrimeField<Repr = [u8; 32]>>(ff: Vec<FF>) -> Vec<
     ff.into_iter().map(|f| ff_to_ruint(f)).collect()
 }
 
+pub fn ark_to_spartan_unsafe<AF: ArkPrimeField, FF: GenericPrimeField<Repr = [u8; 32]> + SerdeObject>(ark: AF) -> FF {
+    assert_eq!(std::mem::size_of::<AF>(), 32);
+    let ff: FF;
+    unsafe {
+        let inner = access_ark_private(&ark);
+        ff = std::mem::transmute_copy(&inner);
+    }
+    ff
+}
+
+pub fn spartan_to_ark_unsafe<FF: GenericPrimeField<Repr = [u8; 32]>, AF: ArkPrimeField>(ff: FF) -> AF {
+    assert_eq!(std::mem::size_of::<FF>(), 32);
+    let ark: AF;
+    unsafe {
+        let inner = access_spartan_private(&ff);
+        ark = std::mem::transmute_copy(&inner);
+    }
+    ark
+}
+
+
+unsafe fn access_ark_private<AF: ArkPrimeField>(value: &AF) -> [u8; 32] {
+    let ptr = value as *const AF as *const [u8; 32];
+    *ptr
+}
+
+unsafe fn access_spartan_private<FF: GenericPrimeField<Repr = [u8; 32]>>(value: &FF) -> [u8; 32] {
+    let ptr = value as *const FF as *const [u8; 32];
+    *ptr
+}
 
 #[cfg(test)]
 mod tests {
@@ -135,4 +166,24 @@ mod tests {
             assert_eq!(spartan_value, new_spartan_value);
         }
     }
+
+    #[test]
+    fn unsafe_roundtrip_test() {
+        for _ in 0..100_000 {
+            let spartan_value = random_spartan();
+            let new_spartan_value = ark_to_spartan_unsafe(spartan_to_ark_unsafe::<Spartan2Fr, ArkFr>(spartan_value));
+            assert_eq!(spartan_value, new_spartan_value);
+        }
+
+        let ark_value = ArkFr::from(-1);
+        let new_ark_value = spartan_to_ark_unsafe(ark_to_spartan_unsafe::<ArkFr, Spartan2Fr>(ark_value));
+        assert_eq!(ark_value, new_ark_value);
+
+        for _ in 0..100_000 {
+            let ark_value = random_ark();
+            let new_ark_value = spartan_to_ark_unsafe(ark_to_spartan_unsafe::<ArkFr, Spartan2Fr>(ark_value));
+            assert_eq!(ark_value, new_ark_value);
+        }
+    }
+
 }

--- a/common/src/field_conversion.rs
+++ b/common/src/field_conversion.rs
@@ -49,7 +49,7 @@ pub fn ff_to_ruints<FF: GenericPrimeField<Repr = [u8; 32]>>(ff: Vec<FF>) -> Vec<
     ff.into_iter().map(|f| ff_to_ruint(f)).collect()
 }
 
-pub fn ark_to_spartan_unsafe<AF: ArkPrimeField, FF: GenericPrimeField<Repr = [u8; 32]> + SerdeObject>(ark: AF) -> FF {
+pub fn ark_to_spartan_unsafe<AF: ArkPrimeField, FF: GenericPrimeField<Repr = [u8; 32]>>(ark: AF) -> FF {
     assert_eq!(std::mem::size_of::<AF>(), 32);
     let ff: FF;
     unsafe {

--- a/common/src/field_conversion.rs
+++ b/common/src/field_conversion.rs
@@ -51,6 +51,7 @@ pub fn ff_to_ruints<FF: GenericPrimeField<Repr = [u8; 32]>>(ff: Vec<FF>) -> Vec<
 
 pub fn ark_to_spartan_unsafe<AF: ArkPrimeField, FF: GenericPrimeField<Repr = [u8; 32]>>(ark: AF) -> FF {
     assert_eq!(std::mem::size_of::<AF>(), 32);
+    assert_eq!(std::mem::size_of::<FF>(), 32);
     let ff: FF;
     unsafe {
         let inner = access_ark_private(&ark);
@@ -61,6 +62,7 @@ pub fn ark_to_spartan_unsafe<AF: ArkPrimeField, FF: GenericPrimeField<Repr = [u8
 
 pub fn spartan_to_ark_unsafe<FF: GenericPrimeField<Repr = [u8; 32]>, AF: ArkPrimeField>(ff: FF) -> AF {
     assert_eq!(std::mem::size_of::<FF>(), 32);
+    assert_eq!(std::mem::size_of::<AF>(), 32);
     let ark: AF;
     unsafe {
         let inner = access_spartan_private(&ff);

--- a/common/src/field_conversion.rs
+++ b/common/src/field_conversion.rs
@@ -87,12 +87,13 @@ mod tests {
     use super::*;
 
     fn random_spartan() -> Spartan2Fr {
-        let random = [rand::random::<u64>(); 4];
+        let rand_vec: Vec<u64> = std::iter::repeat_with(|| rand::random::<u64>()).take(4).collect();
+        let random: [u64; 4] = rand_vec.try_into().unwrap();
         Spartan2Fr::from_raw(random)
     }
 
     fn random_ark() -> ArkFr {
-        let random = [rand::random::<u8>(); 32];
+        let random: Vec<u8> = std::iter::repeat_with(|| rand::random::<u8>()).take(32).collect();
         ArkFr::from_be_bytes_mod_order(&random)
     }
 

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -64,10 +64,10 @@ zeroize = { version = "1", default-features = false }
 common = { path = "../common" }
 compiler = { path = "../compiler" }
 
-witness = { git = "https://github.com/philsippl/circom-witness-rs" }
+# witness = { git = "https://github.com/philsippl/circom-witness-rs" }
+witness = { git = "https://github.com/sragss/circom-witness-rs", branch = "non-ruint-eval" }
 ruint = "1.11.1"
 spartan2 = { git = "https://github.com/a16z/Spartan2.git" }
-lazy_static = "1.4.0"
 ark-bn254 = "0.4.0"
 
 

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -127,7 +127,7 @@ impl<F: PrimeField<Repr = [u8; 32]>> Circuit<F> for JoltCircuit<F> {
 
     let jolt_witnesses: Vec<Vec<F>> = (0..NUM_STEPS).into_par_iter().map(|i| {
       // TODO(sragss): Conversion should be smarter (cached: 0, 1, 2^n)
-      let mut step_inputs: Vec<Vec<U256>> = inputs_chunked.iter().map(|v| v[i].iter().map(|v| ff_to_ruint(v.clone())).collect()).collect::<Vec<_>>();
+      let mut step_inputs: Vec<Vec<U256>> = inputs_chunked.iter().map(|v| v[i].iter().cloned().map(ff_to_ruint).collect()).collect();
       step_inputs.push(vec![U256::from(i as u64), ff_to_ruint(inputs_chunked[0][i][0])]); // [step_counter, program_counter]
 
       let input_map: HashMap<String, Vec<U256>> = variable_names

--- a/jolt-core/src/utils/mod.rs
+++ b/jolt-core/src/utils/mod.rs
@@ -16,6 +16,7 @@ pub mod gaussian_elimination;
 pub mod instruction_utils;
 pub mod math;
 pub mod transcript;
+pub mod thread;
 
 /// Converts an integer value to a bitvector (all values {0,1}) of field elements.
 /// Note: ordering has the MSB in the highest index. All of the following represent the integer 1:

--- a/jolt-core/src/utils/thread.rs
+++ b/jolt-core/src/utils/thread.rs
@@ -1,0 +1,5 @@
+use std::thread;
+
+pub fn drop_in_background_thread<T>(data: T) where T: Send + 'static {
+    thread::spawn(move || drop(data));
+}


### PR DESCRIPTION
- Fixes `reassemble_by_segments` algorithm to be 90% faster
- Introduces `unsafe` conversions between Spartan <==> Arkworks representations of 256-bit fields by unsafely casting directly between the two. Otherwise conversions incurred 1-2 field multiplications when converting in and out of montgomery form.
- Reduces cost of Witness computation by 90%. Reduces pre-snark input conversion cost 95%. 
- Points to a fork of `circom-witness-rs` which has an `evaluate_fr` function so we can evaluate the witness using the Arkworks scalar field type rather than: `ark_bn256::Fr -> halo2_curves::bn256::Fr -> Ruint::U256 -> ark_bn256::Fr -> RuintU256 -> halo2_curves::bn256::Fr`. Now we do`ark_bn256::Fr -> halo2_curves::bn256::Fr -> ark_bn256::Fr -> halo2_curves::bn256::Fr` but thanks to the bullet point (2) these are just unsafe casts.
- Fixes a bug where benchmarks used Curve25519 despite Spartan being Bn254 only (this happens to improve field multiplication time by 10-20%)

