### PR TITLE
Fast u64 montgomery conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,13 @@ members = [
 [profile.release]
 debug = 1
 codegen-units = 1
-lto = "fat"
-
-[profile.build-fast]
-inherits = "release"
-incremental = true
 lto = "off"
+incremental = true
+
+[profile.extra-fast]
+inherits = "release"
+lto = "fat"
+incremental = false
 
 [patch.crates-io]
 ark-ff = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     # authors who contributed to Lasso
     "Michael Zhu <mzhu@a16z.com>",
     "Sam Ragsdale <sragsdale@a16z.com>",
-    "Noah Citron <ncitron@a16z.com>"
+    "Noah Citron <ncitron@a16z.com>",
 ]
 edition = "2021"
 description = "The lookup singularity. Based on Spartan; built on Arkworks."
@@ -27,7 +27,7 @@ members = [
     "examples/fibonacci",
     "examples/sha2-ex",
     "examples/sha3-ex",
-    "integration-tests", 
+    "integration-tests",
 ]
 
 [profile.release]
@@ -39,3 +39,8 @@ lto = "fat"
 inherits = "release"
 incremental = true
 lto = "off"
+
+[patch.crates-io]
+ark-ff = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64" }
+ark-ec = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64" }
+ark-serialize = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64" }

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -69,11 +69,10 @@ witness = { git = "https://github.com/sragss/circom-witness-rs", branch = "non-r
 ruint = "1.11.1"
 spartan2 = { git = "https://github.com/a16z/Spartan2.git" }
 ark-bn254 = "0.4.0"
-
+lazy_static = "1.4.0"
 
 [build-dependencies]
 common = { path = "../common" }
-
 
 [lib]
 name = "liblasso"

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -20,9 +20,9 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
 ark-curve25519 = "0.4.0"
-ark-ec = { version = "0.4.2", default-features = false }
-ark-ff = { version = "0.4.2", default-features = false }
-ark-serialize = { version = "0.4.2", default-features = false, features = [
+ark-ec = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64", default-features = false }
+ark-ff = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64", default-features = false }
+ark-serialize = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64", default-features = false, features = [
     "derive",
 ] }
 ark-std = { version = "0.4.0", default-features = false }

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -20,9 +20,9 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
 ark-curve25519 = "0.4.0"
-ark-ec = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64", default-features = false }
-ark-ff = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64", default-features = false }
-ark-serialize = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64", default-features = false, features = [
+ark-ec = { version = "0.4.2", default-features = false }
+ark-ff = { version = "0.4.2", default-features = false }
+ark-serialize = { version = "0.4.2", default-features = false, features = [
     "derive",
 ] }
 ark-std = { version = "0.4.0", default-features = false }

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -79,8 +79,8 @@ mod test {
     #[test]
     fn srl_instruction_e2e() {
         let mut rng = test_rng();
-        const C: usize = 3;
-        const M: usize = 1 << 22;
+        const C: usize = 4;
+        const M: usize = 1 << 16;
         const WORD_SIZE: usize = 32;
 
         for _ in 0..256 {

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -7,6 +7,8 @@
 /// 4. Checks that the result equals the expected value, given by the `lookup_output`
 macro_rules! jolt_instruction_test {
     ($instr:expr) => {
+        use ark_ff::PrimeField;
+        
         let materialized_subtables: Vec<_> = $instr
             .subtables::<Fr>(C)
             .iter()
@@ -23,7 +25,7 @@ macro_rules! jolt_instruction_test {
         }
 
         let actual = $instr.combine_lookups(&subtable_values, C, M);
-        let expected = Fr::from($instr.lookup_entry());
+        let expected = Fr::from_u64($instr.lookup_entry()).unwrap();
 
         assert_eq!(actual, expected, "{:?}", $instr);
     };

--- a/jolt-core/src/jolt/subtable/and.rs
+++ b/jolt-core/src/jolt/subtable/and.rs
@@ -26,7 +26,7 @@ impl<F: PrimeField> LassoSubtable<F> for AndSubtable<F> {
         // Materialize table entries in order where (x | y) ranges 0..M
         for idx in 0..M {
             let (x, y) = split_bits(idx, bits_per_operand);
-            let row = F::from((x & y) as u64);
+            let row = F::from_u64((x & y) as u64).unwrap();
             entries.push(row);
         }
         entries
@@ -42,7 +42,7 @@ impl<F: PrimeField> LassoSubtable<F> for AndSubtable<F> {
         for i in 0..b {
             let x = x[b - i - 1];
             let y = y[b - i - 1];
-            result += F::from(1u64 << i) * x * y;
+            result += F::from_u64(1u64 << i).unwrap() * x * y;
         }
         result
     }

--- a/jolt-core/src/jolt/subtable/eq_msb.rs
+++ b/jolt-core/src/jolt/subtable/eq_msb.rs
@@ -28,7 +28,7 @@ impl<F: PrimeField> LassoSubtable<F> for EqMSBSubtable<F> {
         for idx in 0..M {
             let (x, y) = split_bits(idx, bits_per_operand);
             let row = (x & high_bit) == (y & high_bit);
-            entries.push(F::from(row));
+            entries.push(if row { F::one() } else { F::zero() });
         }
         entries
     }

--- a/jolt-core/src/jolt/subtable/gt_msb.rs
+++ b/jolt-core/src/jolt/subtable/gt_msb.rs
@@ -28,7 +28,7 @@ impl<F: PrimeField> LassoSubtable<F> for GtMSBSubtable<F> {
         for idx in 0..M {
             let (x, y) = split_bits(idx, bits_per_operand);
             let row = (x & high_bit) > (y & high_bit);
-            entries.push(F::from(row));
+            entries.push(if row { F::one() } else { F::zero() });
         }
         entries
     }

--- a/jolt-core/src/jolt/subtable/identity.rs
+++ b/jolt-core/src/jolt/subtable/identity.rs
@@ -18,13 +18,13 @@ impl<F: PrimeField> IdentitySubtable<F> {
 
 impl<F: PrimeField> LassoSubtable<F> for IdentitySubtable<F> {
     fn materialize(&self, M: usize) -> Vec<F> {
-        (0..M).map(|i| F::from(i as u64)).collect()
+        (0..M).map(|i| F::from_u64(i as u64).unwrap()).collect()
     }
 
     fn evaluate_mle(&self, point: &[F]) -> F {
         let mut result = F::zero();
         for i in 0..point.len() {
-            result += F::from(1u64 << i) * point[point.len() - 1 - i];
+            result += F::from_u64(1u64 << i).unwrap() * point[point.len() - 1 - i];
         }
         result
     }

--- a/jolt-core/src/jolt/subtable/lt_abs.rs
+++ b/jolt-core/src/jolt/subtable/lt_abs.rs
@@ -49,7 +49,7 @@ impl<F: PrimeField> LassoSubtable<F> for LtAbsSubtable<F> {
         // Skip i=0
         for i in 1..b {
             result += (F::one() - x[i]) * y[i] * eq_term;
-            eq_term *= F::one() - x[i] - y[i] + F::from(2u64) * x[i] * y[i];
+            eq_term *= F::one() - x[i] - y[i] + F::from_u64(2u64).unwrap() * x[i] * y[i];
         }
         result
     }

--- a/jolt-core/src/jolt/subtable/ltu.rs
+++ b/jolt-core/src/jolt/subtable/ltu.rs
@@ -42,7 +42,7 @@ impl<F: PrimeField> LassoSubtable<F> for LtuSubtable<F> {
         let mut eq_term = F::one();
         for i in 0..b {
             result += (F::one() - x[i]) * y[i] * eq_term;
-            eq_term *= F::one() - x[i] - y[i] + F::from(2u64) * x[i] * y[i];
+            eq_term *= F::one() - x[i] - y[i] + F::from_u64(2u64).unwrap() * x[i] * y[i];
         }
         result
     }

--- a/jolt-core/src/jolt/subtable/or.rs
+++ b/jolt-core/src/jolt/subtable/or.rs
@@ -26,7 +26,7 @@ impl<F: PrimeField> LassoSubtable<F> for OrSubtable<F> {
         // Materialize table entries in order where (x | y) ranges 0..M
         for idx in 0..M {
             let (x, y) = split_bits(idx, bits_per_operand);
-            let row = F::from((x | y) as u64);
+            let row = F::from_u64((x | y) as u64).unwrap();
             entries.push(row);
         }
         entries
@@ -42,7 +42,7 @@ impl<F: PrimeField> LassoSubtable<F> for OrSubtable<F> {
         for i in 0..b {
             let x = x[b - i - 1];
             let y = y[b - i - 1];
-            result += F::from(1u64 << i) * (x + y - x * y);
+            result += F::from_u64(1u64 << i).unwrap() * (x + y - x * y);
         }
         result
     }

--- a/jolt-core/src/jolt/subtable/sll.rs
+++ b/jolt-core/src/jolt/subtable/sll.rs
@@ -42,7 +42,7 @@ impl<F: PrimeField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> LassoSubta
                 .checked_shr(suffix_length as u32)
                 .unwrap_or(0);
 
-            entries.push(F::from(row as u64));
+            entries.push(F::from_u64(row as u64).unwrap());
         }
         entries
     }
@@ -64,7 +64,7 @@ impl<F: PrimeField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> LassoSubta
             let k_bits = (k as usize)
                 .get_bits(log_WORD_SIZE)
                 .iter()
-                .map(|bit| F::from(*bit as u64))
+                .map(|bit| F::from_u64(*bit as u64).unwrap())
                 .collect::<Vec<F>>(); // big-endian
 
             let mut eq_term = F::one();
@@ -84,7 +84,7 @@ impl<F: PrimeField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> LassoSubta
 
             let shift_x_by_k = (0..m_prime)
                 .enumerate()
-                .map(|(j, _)| F::from(1_u64 << (j + k)) * x[b - 1 - j])
+                .map(|(j, _)| F::from_u64(1_u64 << (j + k)).unwrap() * x[b - 1 - j])
                 .fold(F::zero(), |acc, val| acc + val);
 
             result += eq_term * shift_x_by_k;

--- a/jolt-core/src/jolt/subtable/sra_sign.rs
+++ b/jolt-core/src/jolt/subtable/sra_sign.rs
@@ -31,15 +31,15 @@ impl<F: PrimeField, const WORD_SIZE: usize> LassoSubtable<F> for SraSignSubtable
         for idx in 0..M {
             let (x, y) = split_bits(idx, operand_chunk_width);
 
-            let x_sign = F::from(((x >> sign_bit_index) & 1) as u64);
+            let x_sign = F::from_u64(((x >> sign_bit_index) & 1) as u64).unwrap();
 
             let row = (0..(y % WORD_SIZE) as u32)
                 .into_iter()
                 .fold(F::zero(), |acc, i: u32| {
-                    acc + F::from(1_u64 << (WORD_SIZE as u32 - 1 - i)) * x_sign
+                    acc + F::from_u64(1_u64 << (WORD_SIZE as u32 - 1 - i)).unwrap() * x_sign
                 });
 
-            entries.push(F::from(row));
+            entries.push(row);
         }
         entries
     }
@@ -64,7 +64,7 @@ impl<F: PrimeField, const WORD_SIZE: usize> LassoSubtable<F> for SraSignSubtable
             let k_bits = (k as usize)
                 .get_bits(log_WORD_SIZE)
                 .iter()
-                .map(|bit| F::from(*bit as u64))
+                .map(|bit| F::from(*bit))
                 .collect::<Vec<F>>(); // big-endian
 
             let mut eq_term = F::one();
@@ -75,7 +75,7 @@ impl<F: PrimeField, const WORD_SIZE: usize> LassoSubtable<F> for SraSignSubtable
             }
 
             let x_sign_upper = (0..k).into_iter().fold(F::zero(), |acc, i| {
-                acc + F::from(1_u64 << (WORD_SIZE - 1 - i)) * x_sign
+                acc + F::from_u64(1_u64 << (WORD_SIZE - 1 - i)).unwrap() * x_sign
             });
 
             result += eq_term * x_sign_upper;

--- a/jolt-core/src/jolt/subtable/sra_sign.rs
+++ b/jolt-core/src/jolt/subtable/sra_sign.rs
@@ -64,7 +64,7 @@ impl<F: PrimeField, const WORD_SIZE: usize> LassoSubtable<F> for SraSignSubtable
             let k_bits = (k as usize)
                 .get_bits(log_WORD_SIZE)
                 .iter()
-                .map(|bit| F::from(*bit))
+                .map(|bit| if *bit { F::one() } else { F::zero() })
                 .collect::<Vec<F>>(); // big-endian
 
             let mut eq_term = F::one();

--- a/jolt-core/src/jolt/subtable/srl.rs
+++ b/jolt-core/src/jolt/subtable/srl.rs
@@ -39,7 +39,7 @@ impl<F: PrimeField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> LassoSubta
                 .checked_shr((y % WORD_SIZE) as u32)
                 .unwrap_or(0);
 
-            entries.push(F::from(row as u64));
+            entries.push(F::from_u64(row as u64).unwrap());
         }
         entries
     }
@@ -61,7 +61,7 @@ impl<F: PrimeField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> LassoSubta
             let k_bits = (k as usize)
                 .get_bits(log_WORD_SIZE)
                 .iter()
-                .map(|bit| F::from(*bit as u64))
+                .map(|bit| F::from(*bit))
                 .collect::<Vec<F>>(); // big-endian
 
             let mut eq_term = F::one();
@@ -86,7 +86,9 @@ impl<F: PrimeField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> LassoSubta
 
             let shift_x_by_k = (m..chunk_length)
                 .enumerate()
-                .map(|(_, j)| F::from(1_u64 << (b * CHUNK_INDEX + j - k)) * x[b - 1 - j])
+                .map(|(_, j)| {
+                    F::from_u64(1_u64 << (b * CHUNK_INDEX + j - k)).unwrap() * x[b - 1 - j]
+                })
                 .fold(F::zero(), |acc, val: F| acc + val);
 
             result += eq_term * shift_x_by_k;

--- a/jolt-core/src/jolt/subtable/srl.rs
+++ b/jolt-core/src/jolt/subtable/srl.rs
@@ -61,7 +61,7 @@ impl<F: PrimeField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> LassoSubta
             let k_bits = (k as usize)
                 .get_bits(log_WORD_SIZE)
                 .iter()
-                .map(|bit| F::from(*bit))
+                .map(|bit| if *bit { F::one() } else { F::zero() })
                 .collect::<Vec<F>>(); // big-endian
 
             let mut eq_term = F::one();

--- a/jolt-core/src/jolt/subtable/truncate_overflow.rs
+++ b/jolt-core/src/jolt/subtable/truncate_overflow.rs
@@ -31,7 +31,7 @@ impl<F: PrimeField, const WORD_SIZE: usize> LassoSubtable<F>
         let mut entries: Vec<F> = Vec::with_capacity(M);
         for idx in 0..M {
             let (_, lower_bits) = split_bits(idx, cutoff);
-            let row = F::from(lower_bits as u64);
+            let row = F::from_u64(lower_bits as u64).unwrap();
             entries.push(row);
         }
         entries
@@ -43,7 +43,7 @@ impl<F: PrimeField, const WORD_SIZE: usize> LassoSubtable<F>
 
         let mut result = F::zero();
         for i in 0..cutoff {
-            result += F::from(1u64 << i) * point[point.len() - 1 - i];
+            result += F::from_u64(1u64 << i).unwrap() * point[point.len() - 1 - i];
         }
         result
     }

--- a/jolt-core/src/jolt/subtable/xor.rs
+++ b/jolt-core/src/jolt/subtable/xor.rs
@@ -26,7 +26,7 @@ impl<F: PrimeField> LassoSubtable<F> for XorSubtable<F> {
         // Materialize table entries in order where (x | y) ranges 0..M
         for idx in 0..M {
             let (x, y) = split_bits(idx, bits_per_operand);
-            let row = F::from((x ^ y) as u64);
+            let row = F::from_u64((x ^ y) as u64).unwrap();
             entries.push(row);
         }
         entries
@@ -42,7 +42,7 @@ impl<F: PrimeField> LassoSubtable<F> for XorSubtable<F> {
         for i in 0..b {
             let x = x[b - i - 1];
             let y = y[b - i - 1];
-            result += F::from(1u64 << i) * ((F::one() - x) * y + x * (F::one() - y));
+            result += F::from_u64(1u64 << i).unwrap() * ((F::one() - x) * y + x * (F::one() - y));
         }
         result
     }

--- a/jolt-core/src/jolt/subtable/zero_lsb.rs
+++ b/jolt-core/src/jolt/subtable/zero_lsb.rs
@@ -19,14 +19,16 @@ impl<F: PrimeField> ZeroLSBSubtable<F> {
 impl<F: PrimeField> LassoSubtable<F> for ZeroLSBSubtable<F> {
     fn materialize(&self, M: usize) -> Vec<F> {
         // always set LSB to 0
-        (0..M).map(|i| F::from((i - (i % 2)) as u64)).collect()
+        (0..M)
+            .map(|i| F::from_u64((i - (i % 2)) as u64).unwrap())
+            .collect()
     }
 
     fn evaluate_mle(&self, point: &[F]) -> F {
         let mut result = F::zero();
         // skip LSB
         for i in 1..point.len() {
-            result += F::from(1u64 << i) * point[point.len() - 1 - i];
+            result += F::from_u64(1u64 << i).unwrap() * point[point.len() - 1 - i];
         }
         result
     }

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -179,11 +179,11 @@ impl<F: PrimeField> FiveTuplePoly<F> {
         let mut imms = Vec::with_capacity(len);
 
         for row in elf {
-            opcodes.push(F::from(row.opcode));
-            rds.push(F::from(row.rd));
-            rs1s.push(F::from(row.rs1));
-            rs2s.push(F::from(row.rs2));
-            imms.push(F::from(row.imm));
+            opcodes.push(F::from_u64(row.opcode).unwrap());
+            rds.push(F::from_u64(row.rd).unwrap());
+            rs1s.push(F::from_u64(row.rs1).unwrap());
+            rs2s.push(F::from_u64(row.rs2).unwrap());
+            imms.push(F::from_u64(row.imm).unwrap());
         }
         // Padding
         for _ in elf.len()..len {
@@ -232,11 +232,11 @@ impl<F: PrimeField> FiveTuplePoly<F> {
         // let mut circuit_flags = Vec::with_capacity(len * 15);
 
         for row in elf {
-            opcodes.push(F::from(row.opcode));
-            rds.push(F::from(row.rd));
-            rs1s.push(F::from(row.rs1));
-            rs2s.push(F::from(row.rs2));
-            imms.push(F::from(row.imm));
+            opcodes.push(F::from_u64(row.opcode).unwrap());
+            rds.push(F::from_u64(row.rd).unwrap());
+            rs1s.push(F::from_u64(row.rs1).unwrap());
+            rs2s.push(F::from_u64(row.rs2).unwrap());
+            imms.push(F::from_u64(row.imm).unwrap());
             // circuit_flags.push(row.circuit_flags_packed::<F>());
         }
 
@@ -345,8 +345,11 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> BytecodePolynomials<F, G> {
         }
 
         // create a closure to convert usize to F vector
-        let to_f_vec =
-            |vec: &Vec<usize>| -> Vec<F> { vec.iter().map(|x| F::from(*x as u64)).collect() };
+        let to_f_vec = |vec: &Vec<usize>| -> Vec<F> {
+            vec.iter()
+                .map(|x| F::from_u64(*x as u64).unwrap())
+                .collect()
+        };
 
         let v_read_write = FiveTuplePoly::from_elf_r1cs(&trace);
 
@@ -547,7 +550,7 @@ where
             .map(|i| {
                 <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
                     &[
-                        F::from(i as u64),
+                        F::from_u64(i as u64).unwrap(),
                         polynomials.v_init_final.opcode[i],
                         polynomials.v_init_final.rd[i],
                         polynomials.v_init_final.rs1[i],
@@ -587,7 +590,7 @@ where
             .map(|i| {
                 <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
                     &[
-                        F::from(i as u64),
+                        F::from_u64(i as u64).unwrap(),
                         polynomials.v_init_final.opcode[i],
                         polynomials.v_init_final.rd[i],
                         polynomials.v_init_final.rs1[i],

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -7,9 +7,8 @@ use std::{collections::HashMap, marker::PhantomData};
 
 use crate::jolt::trace::{rv::RVTraceRow, JoltProvableTrace};
 use crate::poly::eq_poly::EqPolynomial;
-use crate::poly::hyrax::{HyraxCommitment, HyraxGenerators};
-use crate::poly::pedersen::PedersenInit;
-use crate::utils::math::Math;
+use crate::poly::hyrax::matrix_dimensions;
+use crate::poly::pedersen::PedersenGenerators;
 use common::constants::{BYTES_PER_INSTRUCTION, RAM_START_ADDRESS, REGISTER_COUNT};
 use common::RV32IM;
 use common::{to_ram_address, ELFInstruction};
@@ -26,7 +25,7 @@ use crate::{
     subprotocols::batched_commitment::{
         BatchedPolynomialCommitment, BatchedPolynomialOpeningProof,
     },
-    utils::{errors::ProofVerifyError, is_power_of_two},
+    utils::{errors::ProofVerifyError, is_power_of_two, math::Math},
 };
 
 pub type BytecodeProof<F, G> = MemoryCheckingProof<
@@ -406,6 +405,17 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> BytecodePolynomials<F, G> {
             trace.push(ELFRow::no_op(no_op_address));
         }
     }
+
+    /// Computes the maximum number of group generators needed to commit to bytecode
+    /// polynomials using Hyrax, given the maximum bytecode size and maximum trace length.
+    pub fn num_generators(max_bytecode_size: usize, max_trace_length: usize) -> usize {
+        // a_read_write, t_read, v_read_write (opcode, rs1, rs2, rd, imm)
+        let read_write_num_vars = (max_trace_length * 7).log_2();
+        // t_final, v_init_final (opcode, rs1, rs2, rd, imm)
+        let init_final_num_vars = (max_bytecode_size * 6).log_2();
+        let max_num_vars = std::cmp::max(read_write_num_vars, init_final_num_vars);
+        matrix_dimensions(max_num_vars).1.pow2()
+    }
 }
 
 pub struct BatchedBytecodePolynomials<F: PrimeField> {
@@ -463,24 +473,21 @@ where
     }
 
     #[tracing::instrument(skip_all, name = "BytecodePolynomials::commit")]
-    fn commit(batched_polys: &Self::BatchedPolynomials, initializer: &PedersenInit<G>) -> Self::Commitment {
+    fn commit(
+        batched_polys: &Self::BatchedPolynomials,
+        pedersen_generators: &PedersenGenerators<G>,
+    ) -> Self::Commitment {
         let read_write_commitments = batched_polys
             .combined_read_write
-            .combined_commit(initializer);
+            .combined_commit(pedersen_generators);
         let init_final_commitments = batched_polys
             .combined_init_final
-            .combined_commit(initializer);
+            .combined_commit(pedersen_generators);
 
         Self::Commitment {
             read_write_commitments,
             init_final_commitments,
         }
-    }
-
-    fn max_generator_size(batched_polys: &Self::BatchedPolynomials) -> usize {
-        let read_write_num_vars = batched_polys.combined_read_write.get_num_vars();
-        let init_final_num_vars = batched_polys.combined_init_final.get_num_vars();
-        std::cmp::max(read_write_num_vars, init_final_num_vars)
     }
 }
 
@@ -515,76 +522,84 @@ where
         let num_ops = polynomials.a_read_write.len();
         let memory_size = polynomials.v_init_final.opcode.len();
 
-        let read_fingerprints = (0..num_ops).into_par_iter().map(|i| {
-            <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
-                &[
-                    polynomials.a_read_write[i],
-                    polynomials.v_read_write.opcode[i],
-                    polynomials.v_read_write.rd[i],
-                    polynomials.v_read_write.rs1[i],
-                    polynomials.v_read_write.rs2[i],
-                    polynomials.v_read_write.imm[i],
-                    polynomials.t_read[i],
-                ],
-                gamma,
-                tau,
-            )
-        })
-        .collect();
+        let read_fingerprints = (0..num_ops)
+            .into_par_iter()
+            .map(|i| {
+                <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
+                    &[
+                        polynomials.a_read_write[i],
+                        polynomials.v_read_write.opcode[i],
+                        polynomials.v_read_write.rd[i],
+                        polynomials.v_read_write.rs1[i],
+                        polynomials.v_read_write.rs2[i],
+                        polynomials.v_read_write.imm[i],
+                        polynomials.t_read[i],
+                    ],
+                    gamma,
+                    tau,
+                )
+            })
+            .collect();
         let read_leaves = DensePolynomial::new(read_fingerprints);
 
-        let init_fingerprints = (0..memory_size).into_par_iter().map(|i| {
-            <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
-                &[
-                    F::from(i as u64),
-                    polynomials.v_init_final.opcode[i],
-                    polynomials.v_init_final.rd[i],
-                    polynomials.v_init_final.rs1[i],
-                    polynomials.v_init_final.rs2[i],
-                    polynomials.v_init_final.imm[i],
-                    F::zero(),
-                ],
-                gamma,
-                tau,
-            )
-        })
-        .collect();
+        let init_fingerprints = (0..memory_size)
+            .into_par_iter()
+            .map(|i| {
+                <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
+                    &[
+                        F::from(i as u64),
+                        polynomials.v_init_final.opcode[i],
+                        polynomials.v_init_final.rd[i],
+                        polynomials.v_init_final.rs1[i],
+                        polynomials.v_init_final.rs2[i],
+                        polynomials.v_init_final.imm[i],
+                        F::zero(),
+                    ],
+                    gamma,
+                    tau,
+                )
+            })
+            .collect();
         let init_leaves = DensePolynomial::new(init_fingerprints);
 
-        let write_fingerprints = (0..num_ops).into_par_iter().map(|i| {
-            <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
-                &[
-                    polynomials.a_read_write[i],
-                    polynomials.v_read_write.opcode[i],
-                    polynomials.v_read_write.rd[i],
-                    polynomials.v_read_write.rs1[i],
-                    polynomials.v_read_write.rs2[i],
-                    polynomials.v_read_write.imm[i],
-                    polynomials.t_read[i] + F::one(),
-                ],
-                gamma,
-                tau,
-            )
-        })
-        .collect();
+        let write_fingerprints = (0..num_ops)
+            .into_par_iter()
+            .map(|i| {
+                <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
+                    &[
+                        polynomials.a_read_write[i],
+                        polynomials.v_read_write.opcode[i],
+                        polynomials.v_read_write.rd[i],
+                        polynomials.v_read_write.rs1[i],
+                        polynomials.v_read_write.rs2[i],
+                        polynomials.v_read_write.imm[i],
+                        polynomials.t_read[i] + F::one(),
+                    ],
+                    gamma,
+                    tau,
+                )
+            })
+            .collect();
         let write_leaves = DensePolynomial::new(write_fingerprints);
 
-        let final_fingerprints = (0..memory_size).into_par_iter().map(|i| {
-            <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
-                &[
-                    F::from(i as u64),
-                    polynomials.v_init_final.opcode[i],
-                    polynomials.v_init_final.rd[i],
-                    polynomials.v_init_final.rs1[i],
-                    polynomials.v_init_final.rs2[i],
-                    polynomials.v_init_final.imm[i],
-                    polynomials.t_final[i],
-                ],
-                gamma,
-                tau,
-            )
-        })
-        .collect();
+        let final_fingerprints = (0..memory_size)
+            .into_par_iter()
+            .map(|i| {
+                <Self as MemoryCheckingProver<F, G, BytecodePolynomials<F, G>>>::fingerprint(
+                    &[
+                        F::from(i as u64),
+                        polynomials.v_init_final.opcode[i],
+                        polynomials.v_init_final.rd[i],
+                        polynomials.v_init_final.rs1[i],
+                        polynomials.v_init_final.rs2[i],
+                        polynomials.v_init_final.imm[i],
+                        polynomials.t_final[i],
+                    ],
+                    gamma,
+                    tau,
+                )
+            })
+            .collect();
         let final_leaves = DensePolynomial::new(final_fingerprints);
 
         (
@@ -866,8 +881,8 @@ mod tests {
         let mut transcript = Transcript::new(b"test_transcript");
 
         let batched_polys = polys.batch();
-        let initializer: PedersenInit<EdwardsProjective> = HyraxGenerators::new_initializer(10, b"test");
-        let commitments = BytecodePolynomials::commit(&batched_polys, &initializer);
+        let generators = PedersenGenerators::new(10, b"test");
+        let commitments = BytecodePolynomials::commit(&batched_polys, &generators);
         let proof = polys.prove_memory_checking(&polys, &batched_polys, &mut transcript);
 
         let mut transcript = Transcript::new(b"test_transcript");
@@ -893,8 +908,8 @@ mod tests {
         let polys: BytecodePolynomials<Fr, EdwardsProjective> =
             BytecodePolynomials::new(program, trace);
         let batch = polys.batch();
-        let initializer: PedersenInit<EdwardsProjective> = HyraxGenerators::new_initializer(8, b"test");
-        let commitments = BytecodePolynomials::commit(&batch, &initializer);
+        let generators = PedersenGenerators::new(8, b"test");
+        let commitments = BytecodePolynomials::commit(&batch, &generators);
 
         let mut transcript = Transcript::new(b"test_transcript");
 

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -487,7 +487,7 @@ where
             .flat_map_iter(|(subtable_index, subtable)| {
                 let init_fingerprints: Vec<F> = (0..M)
                     .map(|i| {
-                        let a = &F::from(i as u64);
+                        let a = &F::from_u64(i as u64).unwrap();
                         let v = &subtable[i];
                         // let t = F::zero();
                         // Compute h(a,v,t) where t == 0

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -1,19 +1,18 @@
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use itertools::interleave;
+use itertools::{interleave, max};
 use merlin::Transcript;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use rayon::prelude::*;
 use std::any::TypeId;
 use std::marker::PhantomData;
 use strum::{EnumCount, IntoEnumIterator};
 use tracing::trace_span;
 
-use rayon::prelude::*;
-
 use crate::lasso::memory_checking::MultisetHashes;
-use crate::poly::hyrax::HyraxGenerators;
-use crate::poly::pedersen::PedersenInit;
+use crate::poly::hyrax::{matrix_dimensions, HyraxGenerators};
+use crate::poly::pedersen::PedersenGenerators;
 use crate::utils::{mul_0_1_optimized, split_poly_flagged};
 use crate::{
     jolt::{
@@ -52,11 +51,11 @@ where
     /// `m` (# lookups).
     pub dim: Vec<DensePolynomial<F>>,
 
-    /// `C` sized vector of `DensePolynomials` whose evaluations correspond to
+    /// `NUM_MEMORIES` sized vector of `DensePolynomials` whose evaluations correspond to
     /// read access counts to the memory. Each `DensePolynomial` has size `m` (# lookups).
     pub read_cts: Vec<DensePolynomial<F>>,
 
-    /// `C` sized vector of `DensePolynomials` whose evaluations correspond to
+    /// `NUM_MEMORIES` sized vector of `DensePolynomials` whose evaluations correspond to
     /// final access counts to the memory. Each `DensePolynomial` has size M, AKA subtable size.
     pub final_cts: Vec<DensePolynomial<F>>,
 
@@ -133,30 +132,19 @@ where
     }
 
     #[tracing::instrument(skip_all, name = "InstructionPolynomials::commit")]
-    fn commit(batched_polys: &Self::BatchedPolynomials, initializer: &PedersenInit<G>) -> Self::Commitment {
-        let dim_read_commitment = batched_polys
-            .batched_dim_read
-            .combined_commit(initializer);
-        let final_commitment = batched_polys
-            .batched_final
-            .combined_commit(initializer);
-        let E_flag_commitment = batched_polys
-            .batched_E_flag
-            .combined_commit(initializer);
+    fn commit(
+        batched_polys: &Self::BatchedPolynomials,
+        generators: &PedersenGenerators<G>,
+    ) -> Self::Commitment {
+        let dim_read_commitment = batched_polys.batched_dim_read.combined_commit(generators);
+        let final_commitment = batched_polys.batched_final.combined_commit(generators);
+        let E_flag_commitment = batched_polys.batched_E_flag.combined_commit(generators);
 
         Self::Commitment {
             dim_read_commitment,
             final_commitment,
             E_flag_commitment,
         }
-    }
-
-    fn max_generator_size(batched_polys: &Self::BatchedPolynomials) -> usize {
-        let dim_read_num_vars = batched_polys.batched_dim_read.get_num_vars();
-        let final_num_vars = batched_polys.batched_final.get_num_vars();
-        let E_flag_num_vars = batched_polys.batched_E_flag.get_num_vars();
-
-        std::cmp::max(std::cmp::max(dim_read_num_vars, final_num_vars), E_flag_num_vars)
     }
 }
 
@@ -808,6 +796,7 @@ where
     #[tracing::instrument(skip_all, name = "InstructionLookups::prove_lookups")]
     pub fn prove_lookups(
         &self,
+        generators: &PedersenGenerators<G>,
         transcript: &mut Transcript,
     ) -> (
         InstructionLookupsProof<F, G, Subtables>,
@@ -818,8 +807,7 @@ where
 
         let polynomials = self.polynomialize();
         let batched_polys = polynomials.batch();
-        let initializer: PedersenInit<G> = HyraxGenerators::new_initializer(InstructionPolynomials::<F,G>::max_generator_size(&batched_polys), b"LassoV1");
-        let commitment = InstructionPolynomials::commit(&batched_polys, &initializer);
+        let commitment = InstructionPolynomials::commit(&batched_polys, generators);
 
         commitment
             .E_flag_commitment
@@ -1437,6 +1425,18 @@ where
             subtable_lookup_indices.push(access_sequence);
         }
         subtable_lookup_indices
+    }
+
+    /// Computes the maximum number of group generators needed to commit to instruction
+    /// lookup polynomials using Hyrax, given the maximum trace length.
+    pub fn num_generators(max_trace_length: usize) -> usize {
+        let dim_read_num_vars = (max_trace_length * (C + Self::NUM_MEMORIES)).log_2();
+        let final_num_vars = (M * Self::NUM_MEMORIES).log_2();
+        let E_flag_num_vars =
+            (max_trace_length * (Self::NUM_MEMORIES + Self::NUM_INSTRUCTIONS)).log_2();
+
+        let max_num_vars = max([dim_read_num_vars, final_num_vars, E_flag_num_vars]).unwrap();
+        matrix_dimensions(max_num_vars).1.pow2()
     }
 
     /// Maps an index [0, NUM_MEMORIES) -> [0, NUM_SUBTABLES)

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -426,7 +426,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     fn compute_lookup_outputs(instructions: &Vec<Self::InstructionSet>) -> Vec<F> {
         instructions
             .par_iter()
-            .map(|op| F::from(op.lookup_entry()))
+            .map(|op| F::from_u64(op.lookup_entry()).unwrap())
             .collect()
     }
 }

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -2,17 +2,19 @@ use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_std::log2;
 use circom_scotia::r1cs;
+use itertools::max;
 use merlin::Transcript;
 use rayon::prelude::*;
 use std::any::TypeId;
 use strum::{EnumCount, IntoEnumIterator};
 
-use crate::{jolt::{
+use crate::jolt::{
     instruction::{JoltInstruction, Opcode},
     subtable::LassoSubtable,
     vm::timestamp_range_check::TimestampValidityProof,
-}, poly::{hyrax::HyraxGenerators, pedersen::PedersenInit}};
+};
 use crate::lasso::memory_checking::{MemoryCheckingProver, MemoryCheckingVerifier};
+use crate::poly::pedersen::PedersenGenerators;
 use crate::poly::structured_poly::BatchablePolynomials;
 use crate::r1cs::snark::R1CSProof;
 use crate::utils::errors::ProofVerifyError;
@@ -36,7 +38,7 @@ where
     bytecode: BytecodeProof<F, G>,
     read_write_memory: ReadWriteMemoryProof<F, G>,
     instruction_lookups: InstructionLookupsProof<F, G, Subtables>,
-    r1cs: R1CSProof
+    r1cs: R1CSProof,
 }
 
 pub struct JoltPolynomials<F, G>
@@ -59,6 +61,40 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     type InstructionSet: JoltInstruction + Opcode + IntoEnumIterator + EnumCount;
     type Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<TypeId> + Into<usize>;
 
+    #[tracing::instrument(skip_all, name = "Jolt::preprocess")]
+    fn preprocess(
+        max_bytecode_size: usize,
+        max_memory_address: usize,
+        max_trace_length: usize,
+    ) -> PedersenGenerators<G> {
+        // TODO(moodlezoup): move more stuff into preprocessing
+
+        let num_bytecode_generators =
+            BytecodePolynomials::<F, G>::num_generators(max_bytecode_size, max_trace_length);
+        let num_read_write_memory_generators =
+            ReadWriteMemory::<F, G>::num_generators(max_memory_address, max_trace_length);
+        let timestamp_range_check_generators =
+            TimestampValidityProof::<F, G>::num_generators(max_trace_length);
+        let num_instruction_lookup_generators = InstructionLookups::<
+            F,
+            G,
+            Self::InstructionSet,
+            Self::Subtables,
+            C,
+            M,
+        >::num_generators(max_trace_length);
+
+        let max_num_generators = max([
+            num_bytecode_generators,
+            num_read_write_memory_generators,
+            timestamp_range_check_generators,
+            num_instruction_lookup_generators,
+        ])
+        .unwrap();
+
+        PedersenGenerators::new(max_num_generators, b"Jolt v1 Hyrax generators")
+    }
+
     #[tracing::instrument(skip_all, name = "Jolt::prove")]
     fn prove(
         bytecode: Vec<ELFInstruction>,
@@ -66,42 +102,53 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
         memory_trace: Vec<[MemoryOp; MEMORY_OPS_PER_INSTRUCTION]>,
         instructions: Vec<Self::InstructionSet>,
         circuit_flags: Vec<F>,
+        generators: PedersenGenerators<G>,
     ) -> (JoltProof<F, G, Self::Subtables>, JoltCommitments<G>) {
         let mut transcript = Transcript::new(b"Jolt transcript");
         let bytecode_rows: Vec<ELFRow> = bytecode.iter().map(ELFRow::from).collect();
-        let (bytecode_proof, bytecode_polynomials, bytecode_commitment) =
-            Self::prove_bytecode(bytecode_rows.clone(), bytecode_trace.clone(), &mut transcript);
-
+        let (bytecode_proof, bytecode_polynomials, bytecode_commitment) = Self::prove_bytecode(
+            bytecode_rows.clone(),
+            bytecode_trace.clone(),
+            &generators,
+            &mut transcript,
+        );
 
         // - prove_r1cs() memory_trace R1CS is not 2-padded
         // - prove_memory() memory_trace    is 2-padded
         let mut padded_memory_trace = memory_trace.clone();
-        padded_memory_trace.resize(memory_trace.len().next_power_of_two(), std::array::from_fn(|_| MemoryOp::no_op()));
+        padded_memory_trace.resize(
+            memory_trace.len().next_power_of_two(),
+            std::array::from_fn(|_| MemoryOp::no_op()),
+        );
 
-        let (memory_proof, memory_polynomials, memory_commitment) =
-            Self::prove_memory(bytecode.clone(), padded_memory_trace, &mut transcript);
-        
+        let (memory_proof, memory_polynomials, memory_commitment) = Self::prove_memory(
+            bytecode.clone(),
+            padded_memory_trace,
+            &generators,
+            &mut transcript,
+        );
+
         let (
             instruction_lookups_proof,
             instruction_lookups_polynomials,
             instruction_lookups_commitment,
-        ) = Self::prove_instruction_lookups(instructions.clone(), &mut transcript);
-
+        ) = Self::prove_instruction_lookups(instructions.clone(), &generators, &mut transcript);
 
         let r1cs_proof = Self::prove_r1cs(
-            instructions, 
-            bytecode_rows, 
-            bytecode_trace, 
-            bytecode, 
+            instructions,
+            bytecode_rows,
+            bytecode_trace,
+            bytecode,
             memory_trace.into_iter().flatten().collect(),
-            circuit_flags, 
-            &mut transcript);
+            circuit_flags,
+            &mut transcript,
+        );
 
         let jolt_proof = JoltProof {
             bytecode: bytecode_proof,
             read_write_memory: memory_proof,
             instruction_lookups: instruction_lookups_proof,
-            r1cs: r1cs_proof
+            r1cs: r1cs_proof,
         };
         let _jolt_polynomials = JoltPolynomials {
             bytecode: bytecode_polynomials,
@@ -132,7 +179,10 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
             commitments.instruction_lookups,
             &mut transcript,
         )?;
-        proof.r1cs.verify().map_err(|e| ProofVerifyError::SpartanError(e.to_string()))?;
+        proof
+            .r1cs
+            .verify()
+            .map_err(|e| ProofVerifyError::SpartanError(e.to_string()))?;
 
         Ok(())
     }
@@ -140,6 +190,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     #[tracing::instrument(skip_all, name = "Jolt::prove_instruction_lookups")]
     fn prove_instruction_lookups(
         ops: Vec<Self::InstructionSet>,
+        generators: &PedersenGenerators<G>,
         transcript: &mut Transcript,
     ) -> (
         InstructionLookupsProof<F, G, Self::Subtables>,
@@ -148,7 +199,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     ) {
         let instruction_lookups =
             InstructionLookups::<F, G, Self::InstructionSet, Self::Subtables, C, M>::new(ops);
-        instruction_lookups.prove_lookups(transcript)
+        instruction_lookups.prove_lookups(generators, transcript)
     }
 
     fn verify_instruction_lookups(
@@ -165,6 +216,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     fn prove_bytecode(
         bytecode_rows: Vec<ELFRow>,
         trace: Vec<ELFRow>,
+        generators: &PedersenGenerators<G>,
         transcript: &mut Transcript,
     ) -> (
         BytecodeProof<F, G>,
@@ -173,8 +225,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     ) {
         let polys: BytecodePolynomials<F, G> = BytecodePolynomials::new(bytecode_rows, trace);
         let batched_polys = polys.batch();
-        let initializer: PedersenInit<G> = HyraxGenerators::new_initializer(BytecodePolynomials::<F,G>::max_generator_size(&batched_polys), b"LassoV1");
-        let commitment = BytecodePolynomials::commit(&batched_polys, &initializer);
+        let commitment = BytecodePolynomials::commit(&batched_polys, &generators);
 
         let proof = polys.prove_memory_checking(&polys, &batched_polys, transcript);
         (proof, polys, commitment)
@@ -192,6 +243,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     fn prove_memory(
         bytecode: Vec<ELFInstruction>,
         memory_trace: Vec<[MemoryOp; MEMORY_OPS_PER_INSTRUCTION]>,
+        generators: &PedersenGenerators<G>,
         transcript: &mut Transcript,
     ) -> (
         ReadWriteMemoryProof<F, G>,
@@ -200,8 +252,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
     ) {
         let (memory, read_timestamps) = ReadWriteMemory::new(bytecode, memory_trace, transcript);
         let batched_polys = memory.batch();
-        let initializer: PedersenInit<G> = HyraxGenerators::new_initializer(ReadWriteMemory::<F,G>::max_generator_size(&batched_polys), b"LassoV1");
-        let commitment: MemoryCommitment<G> = ReadWriteMemory::commit(&batched_polys, &initializer);
+        let commitment: MemoryCommitment<G> = ReadWriteMemory::commit(&batched_polys, &generators);
 
         let memory_checking_proof =
             memory.prove_memory_checking(&memory, &batched_polys, transcript);
@@ -211,6 +262,7 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
             &memory,
             &batched_polys,
             &commitment,
+            &generators,
             transcript,
         );
 
@@ -323,10 +375,10 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
         assert_eq!(lookup_outputs.len(), TRACE_LEN);
         assert_eq!(circuit_flags.len(), TRACE_LEN * N_FLAGS);
 
-        // let padded_trace_len = next power of 2 from trace_eln 
+        // let padded_trace_len = next power of 2 from trace_eln
         let PADDED_TRACE_LEN = TRACE_LEN.next_power_of_two();
 
-        // pad each of the above vectors to be of length PADDED_TRACE_LEN * their multiple 
+        // pad each of the above vectors to be of length PADDED_TRACE_LEN * their multiple
         prog_a_rw.resize(PADDED_TRACE_LEN, Default::default());
         prog_v_rw.resize(PADDED_TRACE_LEN * 6, Default::default());
         memreg_a_rw.resize(PADDED_TRACE_LEN * 7, Default::default());
@@ -338,7 +390,10 @@ pub trait Jolt<'a, F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize
         lookup_outputs.resize(PADDED_TRACE_LEN, Default::default());
 
         let mut circuit_flags_padded = circuit_flags.clone();
-        circuit_flags_padded.extend(vec![F::from(0_u64); PADDED_TRACE_LEN * N_FLAGS - circuit_flags.len()]);
+        circuit_flags_padded.extend(vec![
+            F::from(0_u64);
+            PADDED_TRACE_LEN * N_FLAGS - circuit_flags.len()
+        ]);
         // circuit_flags.resize(PADDED_TRACE_LEN * N_FLAGS, Default::default());
 
         let inputs = vec![

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -453,8 +453,12 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> ReadWriteMemory<F, G> {
         drop(_enter);
         drop(span);
 
-        let to_f_vec =
-            |v: &Vec<u64>| -> Vec<F> { v.into_par_iter().map(|i| F::from(*i)).collect::<Vec<F>>() };
+        // create a closure to convert u64 to F vector
+        let to_f_vec = |v: &Vec<u64>| -> Vec<F> {
+            v.par_iter()
+                .map(|i| F::from_u64(*i).unwrap())
+                .collect::<Vec<F>>()
+        };
 
         let un_remap_address = |a: &Vec<u64>| {
             a.iter()
@@ -786,14 +790,14 @@ where
 
         let init_fingerprints = (0..self.memory_size)
             .into_par_iter()
-            .map(|i| /* 0 * gamma^2 + */ mul_0_optimized(&polynomials.v_init[i], gamma) + F::from(i as u64) - *tau)
+            .map(|i| /* 0 * gamma^2 + */ mul_0_optimized(&polynomials.v_init[i], gamma) + F::from_u64(i as u64).unwrap() - *tau)
             .collect();
         let final_fingerprints = (0..self.memory_size)
             .into_par_iter()
             .map(|i| {
                 mul_0_optimized(&polynomials.t_final[i], &gamma_squared)
                     + mul_0_optimized(&polynomials.v_final[i], gamma)
-                    + F::from(i as u64)
+                    + F::from_u64(i as u64).unwrap()
                     - *tau
             })
             .collect();

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -329,7 +329,8 @@ where
                 let read_fingerprints_0: Vec<F> = (0..M)
                     .into_par_iter()
                     .map(|j| {
-                        let read_timestamp = F::from(polynomials.read_timestamps[i][j]);
+                        let read_timestamp =
+                            F::from_u64(polynomials.read_timestamps[i][j]).unwrap();
                         polynomials.read_cts_read_timestamp[i][j] * gamma_squared
                             + read_timestamp * gamma
                             + read_timestamp
@@ -345,7 +346,7 @@ where
                     .into_par_iter()
                     .map(|j| {
                         let global_minus_read =
-                            F::from(j as u64 - polynomials.read_timestamps[i][j]);
+                            F::from_u64(j as u64 - polynomials.read_timestamps[i][j]).unwrap();
                         polynomials.read_cts_global_minus_read[i][j] * gamma_squared
                             + global_minus_read * gamma
                             + global_minus_read
@@ -369,7 +370,7 @@ where
         let init_fingerprints = (0..M)
             .into_par_iter()
             .map(|i| {
-                let index = F::from(i as u64);
+                let index = F::from_u64(i as u64).unwrap();
                 // 0 * gamma^2 +
                 index * gamma + index - tau
             })

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -460,7 +460,7 @@ where
 mod tests {
     use std::collections::HashSet;
 
-    use crate::poly::pedersen::PedersenInit;
+    use crate::poly::pedersen::PedersenGenerators;
 
     use super::*;
     use ark_curve25519::{EdwardsProjective, Fr};
@@ -510,10 +510,7 @@ mod tests {
             fn batch(&self) -> Self::BatchedPolynomials {
                 unimplemented!()
             }
-            fn commit(_batched_polys: &Self::BatchedPolynomials, initializer: &PedersenInit<EdwardsProjective>) -> Self::Commitment {
-                unimplemented!()
-            }
-            fn max_generator_size(_batched_polys: &Self::BatchedPolynomials) -> usize {
+            fn commit(_batched_polys: &Self::BatchedPolynomials, generators: &PedersenGenerators<EdwardsProjective>) -> Self::Commitment {
                 unimplemented!()
             }
         }
@@ -713,10 +710,7 @@ mod tests {
             fn batch(&self) -> Self::BatchedPolynomials {
                 unimplemented!()
             }
-            fn commit(_batched_polys: &Self::BatchedPolynomials, _generator: &PedersenInit<EdwardsProjective>) -> Self::Commitment {
-                unimplemented!()
-            }
-            fn max_generator_size(_batched_polys: &Self::BatchedPolynomials) -> usize {
+            fn commit(_batched_polys: &Self::BatchedPolynomials, generators: &PedersenGenerators<EdwardsProjective>) -> Self::Commitment {
                 unimplemented!()
             }
         }
@@ -962,10 +956,7 @@ mod tests {
             fn batch(&self) -> Self::BatchedPolynomials {
                 unimplemented!()
             }
-            fn commit(_batched_polys: &Self::BatchedPolynomials, _initializer: &PedersenInit<EdwardsProjective>) -> Self::Commitment {
-                unimplemented!()
-            }
-            fn max_generator_size(_batched_polys: &Self::BatchedPolynomials) -> usize {
+            fn commit(_batched_polys: &Self::BatchedPolynomials, generators: &PedersenGenerators<EdwardsProjective>) -> Self::Commitment {
                 unimplemented!()
             }
         }

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -1,25 +1,25 @@
-use std::marker::{PhantomData, Sync};
-
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use merlin::Transcript;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use std::marker::{PhantomData, Sync};
 
 use crate::{
     jolt::instruction::JoltInstruction,
     lasso::memory_checking::{MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier},
     poly::{
-        dense_mlpoly::DensePolynomial, eq_poly::EqPolynomial, hyrax::HyraxGenerators, identity_poly::IdentityPolynomial, pedersen::PedersenInit, structured_poly::{BatchablePolynomials, StructuredOpeningProof}
+        dense_mlpoly::DensePolynomial,
+        eq_poly::EqPolynomial,
+        hyrax::matrix_dimensions,
+        identity_poly::IdentityPolynomial,
+        pedersen::PedersenGenerators,
+        structured_poly::{BatchablePolynomials, StructuredOpeningProof},
     },
     subprotocols::{
         batched_commitment::{BatchedPolynomialCommitment, BatchedPolynomialOpeningProof},
         sumcheck::SumcheckInstanceProof,
     },
-    utils::{
-        errors::ProofVerifyError, math::Math, mul_0_1_optimized, 
-        transcript::ProofTranscript,
-    },
+    utils::{errors::ProofVerifyError, math::Math, mul_0_1_optimized, transcript::ProofTranscript},
 };
 
 pub struct SurgePolys<F: PrimeField, G: CurveGroup<ScalarField = F>> {
@@ -70,30 +70,23 @@ where
     }
 
     #[tracing::instrument(skip_all, name = "SurgePolys::commit")]
-    fn commit(batched_polys: &Self::BatchedPolynomials, initializer: &PedersenInit<G>) -> Self::Commitment {
+    fn commit(
+        batched_polys: &Self::BatchedPolynomials,
+        pedersen_generators: &PedersenGenerators<G>,
+    ) -> Self::Commitment {
         let dim_read_commitment = batched_polys
             .batched_dim_read
-            .combined_commit(initializer);
+            .combined_commit(pedersen_generators);
         let final_commitment = batched_polys
             .batched_final
-            .combined_commit(initializer);
-        let E_commitment = batched_polys
-            .batched_E
-            .combined_commit(initializer);
+            .combined_commit(pedersen_generators);
+        let E_commitment = batched_polys.batched_E.combined_commit(pedersen_generators);
 
         Self::Commitment {
             dim_read_commitment,
             final_commitment,
             E_commitment,
         }
-    }
-
-    fn max_generator_size(batched_polys: &Self::BatchedPolynomials) -> usize {
-        let dim_read_num_vars = batched_polys.batched_dim_read.get_num_vars();
-        let final_num_vars = batched_polys.batched_final.get_num_vars();
-        let E_num_vars = batched_polys.batched_E.get_num_vars();
-
-        std::cmp::max(std::cmp::max(dim_read_num_vars, final_num_vars), E_num_vars)
     }
 }
 
@@ -520,6 +513,7 @@ where
     }
 
     #[tracing::instrument(skip_all, name = "Surge::new")]
+    // TODO(moodlezoup): we can turn M back into a const generic
     pub fn new(ops: Vec<Instruction>, M: usize) -> Self {
         let num_lookups = ops.len().next_power_of_two();
         let instruction = Instruction::default();
@@ -555,6 +549,18 @@ where
         b"Surge"
     }
 
+    /// Computes the maximum number of group generators needed to commit to Surge polynomials
+    /// using Hyrax, given `M` and the maximum number of lookups.
+    pub fn num_generators(M: usize, max_num_lookups: usize) -> usize {
+        let dim_read_num_vars = (max_num_lookups * 2 * C).log_2();
+        let final_num_vars = (M * C).log_2();
+        let E_num_vars = (max_num_lookups * Self::num_memories()).log_2();
+
+        let max_num_vars =
+            std::cmp::max(std::cmp::max(dim_read_num_vars, final_num_vars), E_num_vars);
+        matrix_dimensions(max_num_vars).1.pow2()
+    }
+
     #[tracing::instrument(skip_all, name = "Surge::prove")]
     pub fn prove(&self, transcript: &mut Transcript) -> SurgeProof<F, G, Instruction, C> {
         <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());
@@ -562,8 +568,9 @@ where
         // TODO(sragss): Move upstream
         let polynomials = self.construct_polys();
         let batched_polys = polynomials.batch();
-        let initializer = HyraxGenerators::new_initializer(SurgePolys::<F,G>::max_generator_size(&batched_polys), b"LassoV1");
-        let commitment = SurgePolys::commit(&batched_polys, &initializer);
+        let pedersen_generators =
+            PedersenGenerators::new(Self::num_generators(self.M, self.num_lookups), b"LassoV1");
+        let commitment = SurgePolys::commit(&batched_polys, &pedersen_generators);
         let num_rounds = self.num_lookups.log_2();
         let instruction = Instruction::default();
 
@@ -575,7 +582,8 @@ where
             b"primary_sumcheck",
             num_rounds,
         );
-        let eq: DensePolynomial<F> = DensePolynomial::new(EqPolynomial::new(r_primary_sumcheck.to_vec()).evals());
+        let eq: DensePolynomial<F> =
+            DensePolynomial::new(EqPolynomial::new(r_primary_sumcheck.to_vec()).evals());
         let sumcheck_claim: F = Self::compute_primary_sumcheck_claim(&polynomials, &eq, self.M);
 
         <Transcript as ProofTranscript<G>>::append_scalar(

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -366,7 +366,7 @@ where
                     .map(|i| {
                         // 0 * gamma^2 +
                         mul_0_1_optimized(&self.materialized_subtables[subtable_index][i], gamma)
-                            + F::from(i as u64)
+                            + F::from_u64(i as u64).unwrap()
                             - *tau
                     })
                     .collect();

--- a/jolt-core/src/lib.rs
+++ b/jolt-core/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![feature(iter_next_chunk)]
+#![allow(long_running_const_eval)]
 
 pub mod benches;
 pub mod jolt;

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -241,16 +241,22 @@ impl<F: PrimeField> DensePolynomial<F> {
         }
     }
 
+    #[tracing::instrument(skip_all, name = "DensePolynomial::from")]
     pub fn from_usize(Z: &[usize]) -> Self {
         DensePolynomial::new(
             (0..Z.len())
-                .map(|i| F::from(Z[i] as u64))
+                .map(|i| F::from_u64(Z[i] as u64).unwrap())
                 .collect::<Vec<F>>(),
         )
     }
 
+    #[tracing::instrument(skip_all, name = "DensePolynomial::from")]
     pub fn from_u64(Z: &[u64]) -> Self {
-        DensePolynomial::new((0..Z.len()).map(|i| F::from(Z[i])).collect::<Vec<F>>())
+        DensePolynomial::new(
+            (0..Z.len())
+                .map(|i| F::from_u64(Z[i]).unwrap())
+                .collect::<Vec<F>>(),
+        )
     }
 }
 

--- a/jolt-core/src/poly/identity_poly.rs
+++ b/jolt-core/src/poly/identity_poly.rs
@@ -15,7 +15,7 @@ impl IdentityPolynomial {
         let len = r.len();
         assert_eq!(len, self.size_point);
         (0..len)
-            .map(|i| F::from((len - i - 1).pow2() as u64) * r[i])
+            .map(|i| F::from_u64((len - i - 1).pow2() as u64).unwrap() * r[i])
             .sum()
     }
 }

--- a/jolt-core/src/poly/structured_poly.rs
+++ b/jolt-core/src/poly/structured_poly.rs
@@ -2,17 +2,16 @@ use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use merlin::Transcript;
 
+use super::pedersen::PedersenGenerators;
 use crate::{
     subprotocols::batched_commitment::BatchedPolynomialOpeningProof,
-    utils::{errors::ProofVerifyError},
+    utils::errors::ProofVerifyError,
 };
-
-use super::{hyrax::HyraxGenerators, pedersen::PedersenInit};
 
 /// Encapsulates the pattern of a collection of related polynomials (e.g. those used to
 /// prove instruction lookups in Jolt) that can be "batched" for more efficient
 /// commitments/openings.
-pub trait BatchablePolynomials<G> {
+pub trait BatchablePolynomials<G: CurveGroup> {
     /// The batched form of these polynomials.
     type BatchedPolynomials;
     /// The batched commitment to these polynomials.
@@ -22,9 +21,10 @@ pub trait BatchablePolynomials<G> {
     /// uses `DensePolynomial::merge` to combine polynomials of the same size.
     fn batch(&self) -> Self::BatchedPolynomials;
     /// Commits to batched polynomials, typically using `DensePolynomial::combined_commit`.
-    fn commit(batched_polys: &Self::BatchedPolynomials, initalizer: &PedersenInit<G>) -> Self::Commitment;
-
-    fn max_generator_size(batched_polys: &Self::BatchedPolynomials) -> usize;
+    fn commit(
+        batched_polys: &Self::BatchedPolynomials,
+        generators: &PedersenGenerators<G>,
+    ) -> Self::Commitment;
 }
 
 /// Encapsulates the pattern of opening a batched polynomial commitment at a single point.

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -33,7 +33,7 @@ impl<F: PrimeField> UniPoly<F> {
 
     fn vandermonde_interpolation(evals: &[F]) -> Vec<F> {
         let n = evals.len();
-        let xs: Vec<F> = (0..n).map(|x| F::from(x as u64)).collect();
+        let xs: Vec<F> = (0..n).map(|x| F::from_u64(x as u64).unwrap()).collect();
 
         let mut vandermonde: Vec<Vec<F>> = Vec::with_capacity(n);
         for i in 0..n {

--- a/jolt-core/src/utils/instruction_utils.rs
+++ b/jolt-core/src/utils/instruction_utils.rs
@@ -13,7 +13,7 @@ pub fn concatenate_lookups<F: PrimeField>(vals: &[F], C: usize, operand_bits: us
 
     let mut sum = F::zero();
     let mut weight = F::one();
-    let shift = F::from(1u64 << operand_bits);
+    let shift = F::from_u64(1u64 << operand_bits).unwrap();
     for i in 0..C {
         sum += weight * vals[C - i - 1];
         weight *= shift;


### PR DESCRIPTION
Uses our fork of `arkworks/algebra` to leverage fast conversion from u64s to field elements (in Montgomery form)
Companion PR: https://github.com/a16z/arkworks-algebra/pull/2