### PR TITLE
implement the bn256 curve conversion between ark and halo2curves

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,6 +10,8 @@ strum_macros = "0.25.3"
 ark-bn254 = "0.4.0"
 ark-ff = "0.4.2"
 ark-std = "0.4.0"
+ark-ec = "0.4.2"
+ark-serialize = "0.4.2"
 bellpepper-core = "0.4.0"
 ff = "0.13.0"
 spartan2 = { git = "https://github.com/a16z/Spartan2"}


### PR DESCRIPTION
@sragss reached me about my [implementation](https://github.com/zkmove/halo2-verifier.move/blob/main/crates/vk-gen-examples/src/to_ark.rs) of the conversion between ark and halo2curves.

He suggests I provide the impl to the repo, so here we are.
