### PR TITLE
Optimize/unused subtable instances

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -71,6 +71,7 @@ spartan2 = { git = "https://github.com/a16z/Spartan2.git" }
 ark-bn254 = "0.4.0"
 lazy_static = "1.4.0"
 halo2curves = "0.6.1"
+fixedbitset = "0.5.0"
 
 [build-dependencies]
 common = { path = "../common" }

--- a/jolt-core/src/jolt/instruction/add.rs
+++ b/jolt-core/src/jolt/instruction/add.rs
@@ -1,6 +1,5 @@
 use ark_ff::PrimeField;
 use ark_std::log2;
-use fixedbitset::FixedBitSet;
 use rand::prelude::StdRng;
 
 use super::{JoltInstruction, SubtableIndices};
@@ -23,26 +22,9 @@ impl<const WORD_SIZE: usize> JoltInstruction for ADDInstruction<WORD_SIZE> {
     }
 
     fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
-        // The first C are from IDEN and the last C are from LOWER9
-        assert!(vals.len() == 2 * C);
-
-        let msb_chunk_index = C - (WORD_SIZE / log2(M) as usize) - 1;
-
-        let mut vals_by_subtable = vals.chunks_exact(C);
-        let identity = vals_by_subtable.next().unwrap();
-        let truncate_overflow = vals_by_subtable.next().unwrap();
-
-        // The output is the LOWER9(most significant chunk) || IDEN of other chunks
-        concatenate_lookups(
-            [
-                &truncate_overflow[0..=msb_chunk_index],
-                &identity[msb_chunk_index + 1..C],
-            ]
-            .concat()
-            .as_slice(),
-            C,
-            log2(M) as usize,
-        )
+        assert!(vals.len() == C);
+        // The output is the TruncateOverflow(most significant chunk) || identity of other chunks
+        concatenate_lookups(vals, C, log2(M) as usize)
     }
 
     fn g_poly_degree(&self, _: usize) -> usize {
@@ -57,11 +39,11 @@ impl<const WORD_SIZE: usize> JoltInstruction for ADDInstruction<WORD_SIZE> {
         let msb_chunk_index = C - (WORD_SIZE / log2(M) as usize) - 1;
         vec![
             (
-                Box::new(IdentitySubtable::new()),
+                Box::new(TruncateOverflowSubtable::<F, WORD_SIZE>::new()),
                 SubtableIndices::from(0..msb_chunk_index + 1),
             ),
             (
-                Box::new(TruncateOverflowSubtable::<F, WORD_SIZE>::new()),
+                Box::new(IdentitySubtable::new()),
                 SubtableIndices::from(msb_chunk_index + 1..C),
             ),
         ]

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -2,7 +2,7 @@ use ark_ff::PrimeField;
 use ark_std::log2;
 use rand::prelude::StdRng;
 
-use super::JoltInstruction;
+use super::{JoltInstruction, SubtableIndices};
 use crate::jolt::subtable::{and::AndSubtable, LassoSubtable};
 use crate::utils::instruction_utils::{chunk_and_concatenate_operands, concatenate_lookups};
 
@@ -22,8 +22,12 @@ impl JoltInstruction for ANDInstruction {
         1
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
-        vec![Box::new(AndSubtable::new())]
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
+        vec![(Box::new(AndSubtable::new()), SubtableIndices::from(0..C))]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
@@ -81,7 +85,7 @@ mod test {
         let instructions = vec![
             ANDInstruction(100, 0),
             ANDInstruction(0, 100),
-            ANDInstruction(1 , 0),
+            ANDInstruction(1, 0),
             ANDInstruction(0, u32_max),
             ANDInstruction(u32_max, 0),
             ANDInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/beq.rs
+++ b/jolt-core/src/jolt/instruction/beq.rs
@@ -3,7 +3,10 @@ use rand::prelude::StdRng;
 
 use super::JoltInstruction;
 use crate::{
-    jolt::subtable::{eq::EqSubtable, LassoSubtable},
+    jolt::{
+        instruction::SubtableIndices,
+        subtable::{eq::EqSubtable, LassoSubtable},
+    },
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
@@ -23,8 +26,12 @@ impl JoltInstruction for BEQInstruction {
         C
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
-        vec![Box::new(EqSubtable::new())]
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
+        vec![(Box::new(EqSubtable::new()), SubtableIndices::from(0..C))]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
@@ -69,7 +76,7 @@ mod test {
         let instructions = vec![
             BEQInstruction(100, 0),
             BEQInstruction(0, 100),
-            BEQInstruction(1 , 0),
+            BEQInstruction(1, 0),
             BEQInstruction(0, u32_max),
             BEQInstruction(u32_max, 0),
             BEQInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -1,7 +1,7 @@
 use ark_ff::PrimeField;
 use rand::prelude::StdRng;
 
-use super::{slt::SLTInstruction, JoltInstruction};
+use super::{slt::SLTInstruction, JoltInstruction, SubtableIndices};
 use crate::{
     jolt::subtable::{
         eq::EqSubtable, eq_abs::EqAbsSubtable, eq_msb::EqMSBSubtable, gt_msb::GtMSBSubtable,
@@ -27,14 +27,18 @@ impl JoltInstruction for BGEInstruction {
         C + 1
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
         vec![
-            Box::new(GtMSBSubtable::new()),
-            Box::new(EqMSBSubtable::new()),
-            Box::new(LtuSubtable::new()),
-            Box::new(EqSubtable::new()),
-            Box::new(LtAbsSubtable::new()),
-            Box::new(EqAbsSubtable::new()),
+            (Box::new(GtMSBSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(EqMSBSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(LtuSubtable::new()), SubtableIndices::from(1..C)),
+            (Box::new(EqSubtable::new()), SubtableIndices::from(1..C)),
+            (Box::new(LtAbsSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(EqAbsSubtable::new()), SubtableIndices::from(0)),
         ]
     }
 
@@ -89,7 +93,7 @@ mod test {
         let instructions = vec![
             BGEInstruction(100, 0),
             BGEInstruction(0, 100),
-            BGEInstruction(1 , 0),
+            BGEInstruction(1, 0),
             BGEInstruction(0, u32_max),
             BGEInstruction(u32_max, 0),
             BGEInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -1,7 +1,7 @@
 use ark_ff::PrimeField;
 use rand::prelude::StdRng;
 
-use super::{sltu::SLTUInstruction, JoltInstruction};
+use super::{sltu::SLTUInstruction, JoltInstruction, SubtableIndices};
 use crate::{
     jolt::subtable::{eq::EqSubtable, ltu::LtuSubtable, LassoSubtable},
     utils::instruction_utils::chunk_and_concatenate_operands,
@@ -24,8 +24,15 @@ impl JoltInstruction for BGEUInstruction {
         C
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
-        vec![Box::new(LtuSubtable::new()), Box::new(EqSubtable::new())]
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
+        vec![
+            (Box::new(LtuSubtable::new()), SubtableIndices::from(0..C)),
+            (Box::new(EqSubtable::new()), SubtableIndices::from(0..C)),
+        ]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {

--- a/jolt-core/src/jolt/instruction/blt.rs
+++ b/jolt-core/src/jolt/instruction/blt.rs
@@ -1,7 +1,7 @@
 use ark_ff::PrimeField;
 use rand::prelude::StdRng;
 
-use super::JoltInstruction;
+use super::{JoltInstruction, SubtableIndices};
 use crate::{
     jolt::subtable::{
         eq::EqSubtable, eq_abs::EqAbsSubtable, eq_msb::EqMSBSubtable, gt_msb::GtMSBSubtable,
@@ -46,14 +46,18 @@ impl JoltInstruction for BLTInstruction {
         C + 1
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
         vec![
-            Box::new(GtMSBSubtable::new()),
-            Box::new(EqMSBSubtable::new()),
-            Box::new(LtuSubtable::new()),
-            Box::new(EqSubtable::new()),
-            Box::new(LtAbsSubtable::new()),
-            Box::new(EqAbsSubtable::new()),
+            (Box::new(GtMSBSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(EqMSBSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(LtuSubtable::new()), SubtableIndices::from(1..C)),
+            (Box::new(EqSubtable::new()), SubtableIndices::from(1..C)),
+            (Box::new(LtAbsSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(EqAbsSubtable::new()), SubtableIndices::from(0)),
         ]
     }
 
@@ -103,7 +107,7 @@ mod test {
         let instructions = vec![
             BLTInstruction(100, 0),
             BLTInstruction(0, 100),
-            BLTInstruction(1 , 0),
+            BLTInstruction(1, 0),
             BLTInstruction(0, u32_max),
             BLTInstruction(u32_max, 0),
             BLTInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/bltu.rs
+++ b/jolt-core/src/jolt/instruction/bltu.rs
@@ -1,7 +1,7 @@
 use ark_ff::PrimeField;
 use rand::prelude::StdRng;
 
-use super::JoltInstruction;
+use super::{JoltInstruction, SubtableIndices};
 use crate::{
     jolt::subtable::{eq::EqSubtable, ltu::LtuSubtable, LassoSubtable},
     utils::instruction_utils::chunk_and_concatenate_operands,
@@ -30,8 +30,15 @@ impl JoltInstruction for BLTUInstruction {
         C
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
-        vec![Box::new(LtuSubtable::new()), Box::new(EqSubtable::new())]
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
+        vec![
+            (Box::new(LtuSubtable::new()), SubtableIndices::from(0..C)),
+            (Box::new(EqSubtable::new()), SubtableIndices::from(0..C)),
+        ]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {

--- a/jolt-core/src/jolt/instruction/bltu.rs
+++ b/jolt-core/src/jolt/instruction/bltu.rs
@@ -15,13 +15,17 @@ impl JoltInstruction for BLTUInstruction {
         [self.0, self.1]
     }
 
-    fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, _: usize) -> F {
+    fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
+        let vals_by_subtable = self.slice_values(vals, C, M);
+        let ltu = vals_by_subtable[0];
+        let eq = vals_by_subtable[1];
+
         let mut sum = F::zero();
         let mut eq_prod = F::one();
 
         for i in 0..C {
-            sum += vals[i] * eq_prod;
-            eq_prod *= vals[C + i];
+            sum += ltu[i] * eq_prod;
+            eq_prod *= eq[i];
         }
         sum
     }

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -3,7 +3,10 @@ use rand::prelude::StdRng;
 
 use super::JoltInstruction;
 use crate::{
-    jolt::subtable::{eq::EqSubtable, LassoSubtable},
+    jolt::{
+        instruction::SubtableIndices,
+        subtable::{eq::EqSubtable, LassoSubtable},
+    },
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
@@ -23,8 +26,12 @@ impl JoltInstruction for BNEInstruction {
         C
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
-        vec![Box::new(EqSubtable::new())]
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
+        vec![(Box::new(EqSubtable::new()), SubtableIndices::from(0..C))]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
@@ -72,7 +79,7 @@ mod test {
         let instructions = vec![
             BNEInstruction(100, 0),
             BNEInstruction(0, 100),
-            BNEInstruction(1 , 0),
+            BNEInstruction(1, 0),
             BNEInstruction(0, u32_max),
             BNEInstruction(u32_max, 0),
             BNEInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -33,7 +33,7 @@ pub trait JoltInstruction: Sync + Clone + Debug {
     fn g_poly_degree(&self, C: usize) -> usize;
     /// Returns a Vec of the unique subtable types used by this instruction. For some instructions,
     /// e.g. SLL, the list of subtables depends on the dimension `C`.
-    fn subtables<F: PrimeField>(&self, C: usize) -> Vec<Box<dyn LassoSubtable<F>>>;
+    fn subtables<F: PrimeField>(&self, C: usize, M: usize) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)>;
     /// Converts the instruction operand(s) in their native word-sized representation into a Vec
     /// of subtable lookups indices. The returned Vec is length `C`, with elements in [0, `log_M`).
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize>;
@@ -72,6 +72,10 @@ impl SubtableIndices {
 
     pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
         self.bitset.ones()
+    }
+
+    pub fn len(&self) -> usize {
+        self.bitset.count_ones(..)
     }
 }
 

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -1,5 +1,4 @@
 use ark_ff::PrimeField;
-use ark_std::log2;
 use enum_dispatch::enum_dispatch;
 use fixedbitset::*;
 use rand::prelude::StdRng;

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -54,6 +54,17 @@ pub trait JoltInstruction: Sync + Clone + Debug {
             .unwrap()
     }
     fn random(&self, rng: &mut StdRng) -> Self;
+
+    fn slice_values<'a, F: PrimeField>(&self, vals: &'a [F], C: usize, M: usize) -> Vec<&'a [F]> {
+        let mut offset = 0;
+        let mut slices = vec![];
+        for (_, indices) in self.subtables::<F>(C, M) {
+            slices.push(&vals[offset..offset + indices.len()]);
+            offset += indices.len();
+        }
+        assert_eq!(offset, vals.len());
+        slices
+    }
 }
 
 pub trait Opcode {
@@ -85,6 +96,10 @@ impl SubtableIndices {
 
     pub fn len(&self) -> usize {
         self.bitset.count_ones(..)
+    }
+
+    pub fn contains(&self, index: usize) -> bool {
+        self.bitset.contains(index)
     }
 }
 

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -2,7 +2,7 @@ use ark_ff::PrimeField;
 use ark_std::log2;
 use rand::prelude::StdRng;
 
-use super::JoltInstruction;
+use super::{JoltInstruction, SubtableIndices};
 use crate::jolt::subtable::{or::OrSubtable, LassoSubtable};
 use crate::utils::instruction_utils::{chunk_and_concatenate_operands, concatenate_lookups};
 
@@ -22,8 +22,12 @@ impl JoltInstruction for ORInstruction {
         1
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
-        vec![Box::new(OrSubtable::new())]
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
+        vec![(Box::new(OrSubtable::new()), SubtableIndices::from(0..C))]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
@@ -67,7 +71,7 @@ mod test {
         let instructions = vec![
             ORInstruction(100, 0),
             ORInstruction(0, 100),
-            ORInstruction(1 , 0),
+            ORInstruction(1, 0),
             ORInstruction(0, u32_max),
             ORInstruction(u32_max, 0),
             ORInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/sll.rs
+++ b/jolt-core/src/jolt/instruction/sll.rs
@@ -18,16 +18,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SLLInstruction<WORD_SIZE> {
 
     fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
         assert!(C <= 10);
-        assert!(vals.len() == C * C);
-
-        let mut subtable_vals = vals.chunks_exact(C);
-        let mut vals_filtered: Vec<F> = Vec::with_capacity(C);
-        for i in 0..C {
-            let subtable_val = subtable_vals.next().unwrap();
-            vals_filtered.extend_from_slice(&subtable_val[i..i + 1]);
-        }
-
-        concatenate_lookups(&vals_filtered, C, (log2(M) / 2) as usize)
+        concatenate_lookups(vals, C, (log2(M) / 2) as usize)
     }
 
     fn g_poly_degree(&self, _: usize) -> usize {
@@ -53,7 +44,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SLLInstruction<WORD_SIZE> {
         ];
         subtables.truncate(C);
         subtables.reverse();
-        
+
         let indices = (0..C).into_iter().map(|i| SubtableIndices::from(i));
         subtables.into_iter().zip(indices).collect()
     }

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -18,24 +18,24 @@ impl JoltInstruction for SLTInstruction {
         [self.0, self.1]
     }
 
-    fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, _: usize) -> F {
-        debug_assert!(vals.len() % C == 0);
-        let mut vals_by_subtable = vals.chunks_exact(C);
-
-        let gt_msb = vals_by_subtable.next().unwrap();
-        let eq_msb = vals_by_subtable.next().unwrap();
-        let ltu = vals_by_subtable.next().unwrap();
-        let eq = vals_by_subtable.next().unwrap();
-        let lt_abs = vals_by_subtable.next().unwrap();
-        let eq_abs = vals_by_subtable.next().unwrap();
+    fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
+        let vals_by_subtable = self.slice_values(vals, C, M);
+        
+        let gt_msb = vals_by_subtable[0];
+        let eq_msb = vals_by_subtable[1];
+        let ltu = vals_by_subtable[2];
+        let eq = vals_by_subtable[3];
+        let lt_abs = vals_by_subtable[4];
+        let eq_abs = vals_by_subtable[5];
 
         // Accumulator for LTU(x_{<s}, y_{<s})
         let mut ltu_sum = lt_abs[0];
         // Accumulator for EQ(x_{<s}, y_{<s})
         let mut eq_prod = eq_abs[0];
-        for i in 1..C {
-            ltu_sum += ltu[i] * eq_prod;
-            eq_prod *= eq[i];
+
+        for (ltu_i, eq_i) in ltu.iter().zip(eq) {
+            ltu_sum += *ltu_i * eq_prod;
+            eq_prod *= eq_i;
         }
 
         // x_s * (1 - y_s) + EQ(x_s, y_s) * LTU(x_{<s}, y_{<s})

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -1,7 +1,7 @@
 use ark_ff::PrimeField;
 use rand::prelude::StdRng;
 
-use super::JoltInstruction;
+use super::{JoltInstruction, SubtableIndices};
 use crate::{
     jolt::subtable::{
         eq::EqSubtable, eq_abs::EqAbsSubtable, eq_msb::EqMSBSubtable, gt_msb::GtMSBSubtable,
@@ -46,14 +46,18 @@ impl JoltInstruction for SLTInstruction {
         C + 1
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
         vec![
-            Box::new(GtMSBSubtable::new()),
-            Box::new(EqMSBSubtable::new()),
-            Box::new(LtuSubtable::new()),
-            Box::new(EqSubtable::new()),
-            Box::new(LtAbsSubtable::new()),
-            Box::new(EqAbsSubtable::new()),
+            (Box::new(GtMSBSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(EqMSBSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(LtuSubtable::new()), SubtableIndices::from(1..C)),
+            (Box::new(EqSubtable::new()), SubtableIndices::from(1..C)),
+            (Box::new(LtAbsSubtable::new()), SubtableIndices::from(0)),
+            (Box::new(EqAbsSubtable::new()), SubtableIndices::from(0)),
         ]
     }
 
@@ -78,7 +82,7 @@ mod test {
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};
-    
+
     use super::SLTInstruction;
 
     #[test]

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -18,13 +18,17 @@ impl JoltInstruction for SLTUInstruction {
         [self.0, self.1]
     }
 
-    fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, _: usize) -> F {
+    fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
+        let vals_by_subtable = self.slice_values(vals, C, M);
+        let ltu = vals_by_subtable[0];
+        let eq = vals_by_subtable[1];
+
         let mut sum = F::zero();
         let mut eq_prod = F::one();
 
         for i in 0..C {
-            sum += vals[i] * eq_prod;
-            eq_prod *= vals[C + i];
+            sum += ltu[i] * eq_prod;
+            eq_prod *= eq[i];
         }
         sum
     }
@@ -61,7 +65,7 @@ impl JoltInstruction for SLTUInstruction {
 #[cfg(test)]
 mod test {
     use ark_curve25519::Fr;
-    use ark_std::{test_rng, Zero};
+    use ark_std::test_rng;
     use rand_chacha::rand_core::RngCore;
 
     use crate::{jolt::instruction::JoltInstruction, jolt_instruction_test};

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -3,7 +3,10 @@ use rand::prelude::StdRng;
 
 use super::JoltInstruction;
 use crate::{
-    jolt::subtable::{eq::EqSubtable, ltu::LtuSubtable, LassoSubtable},
+    jolt::{
+        instruction::SubtableIndices,
+        subtable::{eq::EqSubtable, ltu::LtuSubtable, LassoSubtable},
+    },
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
@@ -30,8 +33,15 @@ impl JoltInstruction for SLTUInstruction {
         C
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
-        vec![Box::new(LtuSubtable::new()), Box::new(EqSubtable::new())]
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
+        vec![
+            (Box::new(LtuSubtable::new()), SubtableIndices::from(0..C)),
+            (Box::new(EqSubtable::new()), SubtableIndices::from(0..C)),
+        ]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
@@ -78,7 +88,7 @@ mod test {
         let instructions = vec![
             SLTUInstruction(100, 0),
             SLTUInstruction(0, 100),
-            SLTUInstruction(1 , 0),
+            SLTUInstruction(1, 0),
             SLTUInstruction(0, u32_max),
             SLTUInstruction(u32_max, 0),
             SLTUInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -1,7 +1,7 @@
 use ark_ff::PrimeField;
 use rand::prelude::StdRng;
 
-use super::JoltInstruction;
+use super::{JoltInstruction, SubtableIndices};
 use crate::jolt::subtable::{srl::SrlSubtable, LassoSubtable};
 use crate::utils::instruction_utils::{assert_valid_parameters, chunk_and_concatenate_for_shift};
 
@@ -31,7 +31,11 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {
         1
     }
 
-    fn subtables<F: PrimeField>(&self, C: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
         let mut subtables: Vec<Box<dyn LassoSubtable<F>>> = vec![
             Box::new(SrlSubtable::<F, 0, WORD_SIZE>::new()),
             Box::new(SrlSubtable::<F, 1, WORD_SIZE>::new()),
@@ -46,7 +50,9 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {
         ];
         subtables.truncate(C);
         subtables.reverse();
-        subtables
+        
+        let indices = (0..C).into_iter().map(|i| SubtableIndices::from(i));
+        subtables.into_iter().zip(indices).collect()
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
@@ -92,7 +98,7 @@ mod test {
         let instructions = vec![
             SRLInstruction::<32>(100, 0),
             SRLInstruction::<32>(0, 100),
-            SRLInstruction::<32>(1 , 0),
+            SRLInstruction::<32>(1, 0),
             SRLInstruction::<32>(0, u32_max),
             SRLInstruction::<32>(u32_max, 0),
             SRLInstruction::<32>(u32_max, u32_max),

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -15,16 +15,8 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {
 
     fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
         assert!(C <= 10);
-        assert!(vals.len() == C * C);
-
-        let mut subtable_vals = vals.chunks_exact(C);
-        let mut vals_filtered: Vec<F> = Vec::with_capacity(C);
-        for i in 0..C {
-            let subtable_val = subtable_vals.next().unwrap();
-            vals_filtered.extend_from_slice(&subtable_val[i..i + 1]);
-        }
-
-        vals_filtered.iter().sum()
+        assert!(vals.len() == C);
+        vals.iter().sum()
     }
 
     fn g_poly_degree(&self, _: usize) -> usize {
@@ -50,7 +42,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {
         ];
         subtables.truncate(C);
         subtables.reverse();
-        
+
         let indices = (0..C).into_iter().map(|i| SubtableIndices::from(i));
         subtables.into_iter().zip(indices).collect()
     }

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -13,7 +13,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {
         [self.0, self.1]
     }
 
-    fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, M: usize) -> F {
+    fn combine_lookups<F: PrimeField>(&self, vals: &[F], C: usize, _: usize) -> F {
         assert!(C <= 10);
         assert!(vals.len() == C);
         vals.iter().sum()

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -8,16 +8,17 @@
 macro_rules! jolt_instruction_test {
     ($instr:expr) => {
         use ark_ff::PrimeField;
-        
+
         let materialized_subtables: Vec<_> = $instr
-            .subtables::<Fr>(C)
+            .subtables::<Fr>(C, M)
             .iter()
-            .map(|subtable| subtable.materialize(M))
+            .map(|(subtable, _)| subtable.materialize(M))
             .collect();
 
         let subtable_lookup_indices = $instr.to_indices(C, ark_std::log2(M) as usize);
 
-        let mut subtable_values: Vec<Fr> = Vec::with_capacity(C * $instr.subtables::<Fr>(C).len());
+        let mut subtable_values: Vec<Fr> =
+            Vec::with_capacity(C * $instr.subtables::<Fr>(C, M).len());
         for subtable in materialized_subtables {
             for lookup_index in subtable_lookup_indices.iter() {
                 subtable_values.push(subtable[*lookup_index]);

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -9,25 +9,18 @@ macro_rules! jolt_instruction_test {
     ($instr:expr) => {
         use ark_ff::PrimeField;
 
-        let materialized_subtables: Vec<_> = $instr
-            .subtables::<Fr>(C, M)
-            .iter()
-            .map(|(subtable, _)| subtable.materialize(M))
-            .collect();
-
         let subtable_lookup_indices = $instr.to_indices(C, ark_std::log2(M) as usize);
-
-        let mut subtable_values: Vec<Fr> =
-            Vec::with_capacity(C * $instr.subtables::<Fr>(C, M).len());
-        for subtable in materialized_subtables {
-            for lookup_index in subtable_lookup_indices.iter() {
-                subtable_values.push(subtable[*lookup_index]);
+        
+        let mut subtable_values: Vec<Fr> = vec![];
+        for (subtable, dimension_indices) in $instr.subtables::<Fr>(C, M) {
+            let materialized_subtable = subtable.materialize(M);
+            for i in dimension_indices.iter() {
+                subtable_values.push(materialized_subtable[subtable_lookup_indices[i]]);
             }
         }
 
         let actual = $instr.combine_lookups(&subtable_values, C, M);
         let expected = Fr::from_u64($instr.lookup_entry()).unwrap();
-
         assert_eq!(actual, expected, "{:?}", $instr);
     };
 }

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -3,6 +3,7 @@ use ark_std::log2;
 use rand::prelude::StdRng;
 
 use super::JoltInstruction;
+use crate::jolt::instruction::SubtableIndices;
 use crate::jolt::subtable::{xor::XorSubtable, LassoSubtable};
 use crate::utils::instruction_utils::{chunk_and_concatenate_operands, concatenate_lookups};
 
@@ -22,8 +23,12 @@ impl JoltInstruction for XORInstruction {
         1
     }
 
-    fn subtables<F: PrimeField>(&self, _: usize) -> Vec<Box<dyn LassoSubtable<F>>> {
-        vec![Box::new(XorSubtable::new())]
+    fn subtables<F: PrimeField>(
+        &self,
+        C: usize,
+        _: usize,
+    ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
+        vec![(Box::new(XorSubtable::new()), SubtableIndices::from(0..C))]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {
@@ -66,7 +71,7 @@ mod test {
         let instructions = vec![
             XORInstruction(100, 0),
             XORInstruction(0, 100),
-            XORInstruction(1 , 0),
+            XORInstruction(1, 0),
             XORInstruction(0, u32_max),
             XORInstruction(u32_max, 0),
             XORInstruction(u32_max, u32_max),

--- a/jolt-core/src/jolt/subtable/mod.rs
+++ b/jolt-core/src/jolt/subtable/mod.rs
@@ -9,7 +9,7 @@ pub trait LassoSubtable<F: PrimeField>: 'static + Sync {
     /// The `Jolt` trait has associated enum types `InstructionSet` and `Subtables`.
     /// This function is used to resolve the many-to-many mapping between `InstructionSet` variants
     /// and `Subtables` variants,
-    fn subtable_id(&self) -> TypeId {
+    fn subtable_id(&self) -> SubtableId {
         TypeId::of::<Self>()
     }
     /// Fully materializes a subtable of size `M`, reprensented as a Vec of length `M`.
@@ -18,6 +18,8 @@ pub trait LassoSubtable<F: PrimeField>: 'static + Sync {
     /// interpreted to be of size log_2(M), where M is the size of the subtable.
     fn evaluate_mle(&self, point: &[F]) -> F;
 }
+
+pub type SubtableId = TypeId;
 
 pub mod and;
 pub mod eq;

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -5,11 +5,11 @@ use itertools::{interleave, max};
 use merlin::Transcript;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use rayon::prelude::*;
-use std::any::TypeId;
 use std::marker::PhantomData;
 use strum::{EnumCount, IntoEnumIterator};
 use tracing::trace_span;
 
+use crate::jolt::instruction::SubtableIndices;
 use crate::lasso::memory_checking::MultisetHashes;
 use crate::poly::hyrax::{matrix_dimensions, HyraxGenerators};
 use crate::poly::pedersen::PedersenGenerators;
@@ -17,7 +17,7 @@ use crate::utils::{mul_0_1_optimized, split_poly_flagged};
 use crate::{
     jolt::{
         instruction::{JoltInstruction, Opcode},
-        subtable::LassoSubtable,
+        subtable::{LassoSubtable, SubtableId},
     },
     lasso::memory_checking::{MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier},
     poly::{
@@ -40,7 +40,7 @@ use crate::{
 };
 
 /// All polynomials associated with Jolt instruction lookups.
-pub struct InstructionPolynomials<F, G>
+pub struct InstructionPolynomials<const C: usize, F, G>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
@@ -100,7 +100,7 @@ pub struct InstructionCommitmentGenerators<G: CurveGroup> {
 }
 
 // TODO: macro?
-impl<F, G> BatchablePolynomials<G> for InstructionPolynomials<F, G>
+impl<const C: usize, F, G> BatchablePolynomials<G> for InstructionPolynomials<C, F, G>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
@@ -111,13 +111,15 @@ where
     #[tracing::instrument(skip_all, name = "InstructionPolynomials::batch")]
     fn batch(&self) -> Self::BatchedPolynomials {
         let (batched_dim_read, (batched_final, batched_E_flag)) = rayon::join(
-            || DensePolynomial::merge(self.dim.iter().chain(&self.read_cts)),
+            || DensePolynomial::merge(self.dim.iter().chain(self.read_cts.iter())),
             || {
                 rayon::join(
-                    || DensePolynomial::merge(&self.final_cts),
+                    || DensePolynomial::merge(self.final_cts.iter()),
                     || {
                         DensePolynomial::merge(
-                            self.E_polys.iter().chain(&self.instruction_flag_polys),
+                            self.E_polys
+                                .iter()
+                                .chain(self.instruction_flag_polys.iter()),
                         )
                     },
                 )
@@ -160,10 +162,13 @@ where
     flag_openings: Vec<F>,
 }
 
-impl<F: PrimeField, G: CurveGroup<ScalarField = F>>
-    StructuredOpeningProof<F, G, InstructionPolynomials<F, G>> for PrimarySumcheckOpenings<F>
+impl<const C: usize, F, G> StructuredOpeningProof<F, G, InstructionPolynomials<C, F, G>>
+    for PrimarySumcheckOpenings<F>
+where
+    F: PrimeField,
+    G: CurveGroup<ScalarField = F>,
 {
-    fn open(_polynomials: &InstructionPolynomials<F, G>, _opening_point: &Vec<F>) -> Self {
+    fn open(_polynomials: &InstructionPolynomials<C, F, G>, _opening_point: &Vec<F>) -> Self {
         unimplemented!("Openings are output by sumcheck protocol");
     }
 
@@ -233,7 +238,7 @@ where
     E_flag_opening_proof: BatchedPolynomialOpeningProof<G>,
 }
 
-impl<F, G> StructuredOpeningProof<F, G, InstructionPolynomials<F, G>>
+impl<const C: usize, F, G> StructuredOpeningProof<F, G, InstructionPolynomials<C, F, G>>
     for InstructionReadWriteOpenings<F>
 where
     F: PrimeField,
@@ -242,7 +247,7 @@ where
     type Proof = InstructionReadWriteOpeningProof<F, G>;
 
     #[tracing::instrument(skip_all, name = "InstructionReadWriteOpenings::open")]
-    fn open(polynomials: &InstructionPolynomials<F, G>, opening_point: &Vec<F>) -> Self {
+    fn open(polynomials: &InstructionPolynomials<C, F, G>, opening_point: &Vec<F>) -> Self {
         // All of these evaluations share the lagrange basis polynomials.
         let chis = EqPolynomial::new(opening_point.to_vec()).evals();
 
@@ -360,7 +365,7 @@ where
     v_init_final: Option<Vec<F>>,
 }
 
-impl<F, G, Subtables> StructuredOpeningProof<F, G, InstructionPolynomials<F, G>>
+impl<const C: usize, F, G, Subtables> StructuredOpeningProof<F, G, InstructionPolynomials<C, F, G>>
     for InstructionFinalOpenings<F, Subtables>
 where
     F: PrimeField,
@@ -368,7 +373,7 @@ where
     Subtables: LassoSubtable<F> + IntoEnumIterator,
 {
     #[tracing::instrument(skip_all, name = "InstructionFinalOpenings::open")]
-    fn open(polynomials: &InstructionPolynomials<F, G>, opening_point: &Vec<F>) -> Self {
+    fn open(polynomials: &InstructionPolynomials<C, F, G>, opening_point: &Vec<F>) -> Self {
         // All of these evaluations share the lagrange basis polynomials.
         let chis = EqPolynomial::new(opening_point.to_vec()).evals();
         let final_openings = polynomials
@@ -426,13 +431,17 @@ where
 }
 
 impl<F, G, InstructionSet, Subtables, const C: usize, const M: usize>
-    MemoryCheckingProver<F, G, InstructionPolynomials<F, G>>
-    for InstructionLookups<F, G, InstructionSet, Subtables, C, M>
+    MemoryCheckingProver<
+        F,
+        G,
+        InstructionPolynomials<C, F, G>,
+        InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+    > for InstructionLookupsProof<C, M, F, G, InstructionSet, Subtables>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
     InstructionSet: JoltInstruction + Opcode + IntoEnumIterator + EnumCount,
-    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<TypeId> + Into<usize>,
+    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<SubtableId> + Into<usize>,
 {
     type ReadWriteOpenings = InstructionReadWriteOpenings<F>;
     type InitFinalOpenings = InstructionFinalOpenings<F, Subtables>;
@@ -449,19 +458,20 @@ where
 
     #[tracing::instrument(skip_all, name = "InstructionLookups::compute_leaves")]
     fn compute_leaves(
-        &self,
-        polynomials: &InstructionPolynomials<F, G>,
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        polynomials: &InstructionPolynomials<C, F, G>,
         gamma: &F,
         tau: &F,
     ) -> (Vec<DensePolynomial<F>>, Vec<DensePolynomial<F>>) {
         let gamma_squared = gamma.square();
+        let num_lookups = polynomials.dim[0].len();
 
-        let read_write_leaves = (0..Self::NUM_MEMORIES)
+        let read_write_leaves = (0..preprocessing.num_memories)
             .into_par_iter()
             .flat_map_iter(|memory_index| {
-                let dim_index = Self::memory_to_dimension_index(memory_index);
+                let dim_index = preprocessing.memory_to_dimension_index[memory_index];
 
-                let read_fingerprints: Vec<F> = (0..self.num_lookups)
+                let read_fingerprints: Vec<F> = (0..num_lookups)
                     .map(|i| {
                         let a = &polynomials.dim[dim_index][i];
                         let v = &polynomials.E_polys[memory_index][i];
@@ -480,7 +490,7 @@ where
             })
             .collect();
 
-        let init_final_leaves: Vec<DensePolynomial<F>> = self
+        let init_final_leaves: Vec<DensePolynomial<F>> = preprocessing
             .materialized_subtables
             .par_iter()
             .enumerate()
@@ -495,10 +505,11 @@ where
                     })
                     .collect();
 
-                let final_leaves: Vec<DensePolynomial<F>> = (0..C)
-                    .map(|dim_index| {
-                        let memory_index = C * subtable_index + dim_index;
-                        let final_cts = &polynomials.final_cts[memory_index];
+                let final_leaves: Vec<DensePolynomial<F>> = preprocessing
+                    .subtable_to_memory_indices[subtable_index]
+                    .iter()
+                    .map(|memory_index| {
+                        let final_cts = &polynomials.final_cts[*memory_index];
                         let final_fingerprints = (0..M)
                             .map(|i| {
                                 init_fingerprints[i]
@@ -519,7 +530,10 @@ where
         (read_write_leaves, init_final_leaves)
     }
 
-    fn interleave_hashes(multiset_hashes: &MultisetHashes<F>) -> (Vec<F>, Vec<F>) {
+    fn interleave_hashes(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        multiset_hashes: &MultisetHashes<F>,
+    ) -> (Vec<F>, Vec<F>) {
         // R W R W R W ...
         let read_write_hashes = interleave(
             multiset_hashes.read_hashes.clone(),
@@ -527,6 +541,7 @@ where
         )
         .collect();
 
+        // TODO(moodlezoup): variable number of F per I
         // I F F F F I F F F F ...
         let mut init_final_hashes = Vec::with_capacity(
             multiset_hashes.init_hashes.len() + multiset_hashes.final_hashes.len(),
@@ -542,28 +557,30 @@ where
     }
 
     fn uninterleave_hashes(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
         read_write_hashes: Vec<F>,
         init_final_hashes: Vec<F>,
     ) -> MultisetHashes<F> {
-        assert_eq!(read_write_hashes.len(), 2 * Self::NUM_MEMORIES);
+        assert_eq!(read_write_hashes.len(), 2 * preprocessing.num_memories);
         assert_eq!(
             init_final_hashes.len(),
-            Self::NUM_SUBTABLES + Self::NUM_MEMORIES
+            Self::NUM_SUBTABLES + preprocessing.num_memories
         );
 
-        let mut read_hashes = Vec::with_capacity(Self::NUM_MEMORIES);
-        let mut write_hashes = Vec::with_capacity(Self::NUM_MEMORIES);
-        for i in 0..Self::NUM_MEMORIES {
+        let mut read_hashes = Vec::with_capacity(preprocessing.num_memories);
+        let mut write_hashes = Vec::with_capacity(preprocessing.num_memories);
+        for i in 0..preprocessing.num_memories {
             read_hashes.push(read_write_hashes[2 * i]);
             write_hashes.push(read_write_hashes[2 * i + 1]);
         }
 
         let mut init_hashes = Vec::with_capacity(Self::NUM_SUBTABLES);
-        let mut final_hashes = Vec::with_capacity(Self::NUM_MEMORIES);
+        let mut final_hashes = Vec::with_capacity(preprocessing.num_memories);
         let mut init_final_hashes = init_final_hashes.iter();
         for _ in 0..Self::NUM_SUBTABLES {
             // I
             init_hashes.push(*init_final_hashes.next().unwrap());
+            // TODO(moodlezoup): variable number of F per I
             // F F F F
             for _ in 0..C {
                 final_hashes.push(*init_final_hashes.next().unwrap());
@@ -578,33 +595,48 @@ where
         }
     }
 
-    fn check_multiset_equality(multiset_hashes: &MultisetHashes<F>) {
+    fn check_multiset_equality(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        multiset_hashes: &MultisetHashes<F>,
+    ) {
         assert_eq!(multiset_hashes.init_hashes.len(), Self::NUM_SUBTABLES);
-        assert_eq!(multiset_hashes.read_hashes.len(), Self::NUM_MEMORIES);
-        assert_eq!(multiset_hashes.write_hashes.len(), Self::NUM_MEMORIES);
-        assert_eq!(multiset_hashes.final_hashes.len(), Self::NUM_MEMORIES);
+        assert_eq!(
+            multiset_hashes.read_hashes.len(),
+            preprocessing.num_memories
+        );
+        assert_eq!(
+            multiset_hashes.write_hashes.len(),
+            preprocessing.num_memories
+        );
+        assert_eq!(
+            multiset_hashes.final_hashes.len(),
+            preprocessing.num_memories
+        );
 
-        (0..Self::NUM_MEMORIES).into_par_iter().for_each(|i| {
-            let read_hash = multiset_hashes.read_hashes[i];
-            let write_hash = multiset_hashes.write_hashes[i];
-            let init_hash = multiset_hashes.init_hashes[Self::memory_to_subtable_index(i)];
-            let final_hash = multiset_hashes.final_hashes[i];
-            assert_eq!(
-                init_hash * write_hash,
-                final_hash * read_hash,
-                "Multiset hashes don't match"
-            );
-        });
+        (0..preprocessing.num_memories)
+            .into_par_iter()
+            .for_each(|i| {
+                let read_hash = multiset_hashes.read_hashes[i];
+                let write_hash = multiset_hashes.write_hashes[i];
+                let init_hash =
+                    multiset_hashes.init_hashes[preprocessing.memory_to_subtable_index[i]];
+                let final_hash = multiset_hashes.final_hashes[i];
+                assert_eq!(
+                    init_hash * write_hash,
+                    final_hash * read_hash,
+                    "Multiset hashes don't match"
+                );
+            });
     }
 
     /// Overrides default implementation to handle flags
     #[tracing::instrument(skip_all, name = "InstructionLookups::read_write_grand_product")]
     fn read_write_grand_product(
-        &self,
-        polynomials: &InstructionPolynomials<F, G>,
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        polynomials: &InstructionPolynomials<C, F, G>,
         read_write_leaves: Vec<DensePolynomial<F>>,
     ) -> (BatchedGrandProductCircuit<F>, Vec<F>) {
-        assert_eq!(read_write_leaves.len(), 2 * Self::NUM_MEMORIES);
+        assert_eq!(read_write_leaves.len(), 2 * preprocessing.num_memories);
 
         let _span = trace_span!("InstructionLookups: construct circuits");
         let _enter = _span.enter();
@@ -616,8 +648,8 @@ where
             .enumerate()
             .map(|(i, leaves_poly)| {
                 // Split while cloning to save on future cloning in GrandProductCircuit
-                let subtable_index = Self::memory_to_subtable_index(i / 2);
-                let flag = &subtable_flag_polys[subtable_index];
+                let subtable_index = preprocessing.memory_to_subtable_index[i / 2];
+                let flag: &DensePolynomial<F> = &subtable_flag_polys[subtable_index];
                 let (toggled_leaves_l, toggled_leaves_r) = split_poly_flagged(&leaves_poly, &flag);
                 GrandProductCircuit::new_split(
                     DensePolynomial::new(toggled_leaves_l),
@@ -644,8 +676,8 @@ where
         let _enter = _span.enter();
 
         // self.memory_to_subtable map has to be expanded because we've doubled the number of "grand products memorys": [read_0, write_0, ... read_NUM_MEMOREIS, write_NUM_MEMORIES]
-        let expanded_flag_map: Vec<usize> = (0..2 * Self::NUM_MEMORIES)
-            .map(|i| Self::memory_to_subtable_index(i / 2))
+        let expanded_flag_map: Vec<usize> = (0..2 * preprocessing.num_memories)
+            .map(|i| preprocessing.memory_to_subtable_index[i / 2])
             .collect();
 
         // Prover has access to subtable_flag_polys, which are uncommitted, but verifier can derive from instruction_flag commitments.
@@ -668,20 +700,27 @@ where
 }
 
 impl<F, G, InstructionSet, Subtables, const C: usize, const M: usize>
-    MemoryCheckingVerifier<F, G, InstructionPolynomials<F, G>>
-    for InstructionLookups<F, G, InstructionSet, Subtables, C, M>
+    MemoryCheckingVerifier<
+        F,
+        G,
+        InstructionPolynomials<C, F, G>,
+        InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+    > for InstructionLookupsProof<C, M, F, G, InstructionSet, Subtables>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
     InstructionSet: JoltInstruction + Opcode + IntoEnumIterator + EnumCount,
-    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<TypeId> + Into<usize>,
+    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<SubtableId> + Into<usize>,
 {
-    fn read_tuples(openings: &Self::ReadWriteOpenings) -> Vec<Self::MemoryTuple> {
+    fn read_tuples(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        openings: &Self::ReadWriteOpenings,
+    ) -> Vec<Self::MemoryTuple> {
         let subtable_flags = Self::subtable_flags(&openings.flag_openings);
-        (0..Self::NUM_MEMORIES)
+        (0..preprocessing.num_memories)
             .map(|memory_index| {
-                let subtable_index = Self::memory_to_subtable_index(memory_index);
-                let dim_index = Self::memory_to_dimension_index(memory_index);
+                let subtable_index = preprocessing.memory_to_subtable_index[memory_index];
+                let dim_index = preprocessing.memory_to_dimension_index[memory_index];
                 (
                     openings.dim_openings[dim_index],
                     openings.E_poly_openings[memory_index],
@@ -691,13 +730,19 @@ where
             })
             .collect()
     }
-    fn write_tuples(openings: &Self::ReadWriteOpenings) -> Vec<Self::MemoryTuple> {
-        Self::read_tuples(openings)
+    fn write_tuples(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        openings: &Self::ReadWriteOpenings,
+    ) -> Vec<Self::MemoryTuple> {
+        Self::read_tuples(preprocessing, openings)
             .iter()
             .map(|(a, v, t, flag)| (*a, *v, *t + F::one(), *flag))
             .collect()
     }
-    fn init_tuples(openings: &Self::InitFinalOpenings) -> Vec<Self::MemoryTuple> {
+    fn init_tuples(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        openings: &Self::InitFinalOpenings,
+    ) -> Vec<Self::MemoryTuple> {
         let a_init = openings.a_init_final.unwrap();
         let v_init = openings.v_init_final.as_ref().unwrap();
 
@@ -705,15 +750,18 @@ where
             .map(|subtable_index| (a_init, v_init[subtable_index], F::zero(), None))
             .collect()
     }
-    fn final_tuples(openings: &Self::InitFinalOpenings) -> Vec<Self::MemoryTuple> {
+    fn final_tuples(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        openings: &Self::InitFinalOpenings,
+    ) -> Vec<Self::MemoryTuple> {
         let a_init = openings.a_init_final.unwrap();
         let v_init = openings.v_init_final.as_ref().unwrap();
 
-        (0..Self::NUM_MEMORIES)
+        (0..preprocessing.num_memories)
             .map(|memory_index| {
                 (
                     a_init,
-                    v_init[Self::memory_to_subtable_index(memory_index)],
+                    v_init[preprocessing.memory_to_subtable_index[memory_index]],
                     openings.final_openings[memory_index],
                     None,
                 )
@@ -723,19 +771,21 @@ where
 }
 
 /// Proof of instruction lookups for a single Jolt program execution.
-pub struct InstructionLookupsProof<F, G, Subtables>
+pub struct InstructionLookupsProof<const C: usize, const M: usize, F, G, InstructionSet, Subtables>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
     Subtables: LassoSubtable<F> + IntoEnumIterator,
+    InstructionSet: JoltInstruction + Opcode + IntoEnumIterator + EnumCount,
 {
+    _instructions: PhantomData<InstructionSet>,
     /// "Primary" sumcheck, i.e. proving \sum_x \tilde{eq}(r, x) * \sum_i flag_i(x) * g_i(E_1(x), ..., E_\alpha(x))
     primary_sumcheck: PrimarySumcheck<F, G>,
 
     /// Memory checking proof, showing that E_i polynomials are well-formed.
     memory_checking: MemoryCheckingProof<
         G,
-        InstructionPolynomials<F, G>,
+        InstructionPolynomials<C, F, G>,
         InstructionReadWriteOpenings<F>,
         InstructionFinalOpenings<F, Subtables>,
     >,
@@ -749,63 +799,106 @@ pub struct PrimarySumcheck<F: PrimeField, G: CurveGroup<ScalarField = F>> {
     opening_proof: BatchedPolynomialOpeningProof<G>,
 }
 
-pub struct InstructionLookups<F, G, InstructionSet, Subtables, const C: usize, const M: usize>
-where
+pub struct InstructionLookupsPreprocessing<
+    F,
+    InstructionSet,
+    Subtables,
+    const C: usize,
+    const M: usize,
+> where
     F: PrimeField,
-    G: CurveGroup<ScalarField = F>,
     InstructionSet: JoltInstruction + Opcode + IntoEnumIterator + EnumCount,
-    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<TypeId> + Into<usize>,
+    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<SubtableId> + Into<usize>,
 {
     _field: PhantomData<F>,
-    _group: PhantomData<G>,
     _instructions: PhantomData<InstructionSet>,
     _subtables: PhantomData<Subtables>,
-    ops: Vec<InstructionSet>,
+    subtable_indices: Vec<SubtableIndices>,
+    subtable_to_memory_indices: Vec<Vec<usize>>,
+    instruction_to_memory_indices: Vec<Vec<usize>>, //
+    memory_to_subtable_index: Vec<usize>,           //
+    memory_to_instruction_indices: Vec<Vec<usize>>,
+    memory_to_dimension_index: Vec<usize>, //
     materialized_subtables: Vec<Vec<F>>,
-    num_lookups: usize,
+    num_memories: usize,
 }
 
-impl<F, G, InstructionSet, Subtables, const C: usize, const M: usize>
-    InstructionLookups<F, G, InstructionSet, Subtables, C, M>
+impl<F, InstructionSet, Subtables, const C: usize, const M: usize>
+    InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>
 where
     F: PrimeField,
-    G: CurveGroup<ScalarField = F>,
     InstructionSet: JoltInstruction + Opcode + IntoEnumIterator + EnumCount,
-    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<TypeId> + Into<usize>,
+    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<SubtableId> + Into<usize>,
 {
     const NUM_SUBTABLES: usize = Subtables::COUNT;
     const NUM_INSTRUCTIONS: usize = InstructionSet::COUNT;
-    const NUM_MEMORIES: usize = C * Subtables::COUNT;
 
-    #[tracing::instrument(skip_all, name = "InstructionLookups::new")]
-    pub fn new(ops: Vec<InstructionSet>) -> Self {
+    #[tracing::instrument(skip_all, name = "InstructionLookups::preprocess")]
+    pub fn preprocess() -> Self {
         let materialized_subtables = Self::materialize_subtables();
-        let num_lookups = ops.len().next_power_of_two();
+
+        let mut subtable_indices: Vec<SubtableIndices> =
+            vec![SubtableIndices::with_capacity(C); Self::NUM_SUBTABLES];
+        for instruction in InstructionSet::iter() {
+            for (subtable, indices) in instruction.subtables::<F>(C, M) {
+                subtable_indices[Subtables::from(subtable.subtable_id()).into()]
+                    .union_with(&indices);
+            }
+        }
+
+        let mut num_memories = 0;
+        for v in subtable_indices.iter() {
+            num_memories += v.len();
+        }
+
+        // TODO(moodlezoup)
 
         Self {
             _field: PhantomData,
-            _group: PhantomData,
             _instructions: PhantomData,
             _subtables: PhantomData,
-            ops,
+            subtable_indices,
+            num_memories,
             materialized_subtables,
-            num_lookups,
         }
     }
 
+    /// Materializes all subtables used by this Jolt instance.
+    #[tracing::instrument(skip_all)]
+    fn materialize_subtables() -> Vec<Vec<F>> {
+        let mut subtables = Vec::with_capacity(Subtables::COUNT);
+        for subtable in Subtables::iter() {
+            subtables.push(subtable.materialize(M));
+        }
+        subtables
+    }
+}
+
+impl<F, G, InstructionSet, Subtables, const C: usize, const M: usize>
+    InstructionLookupsProof<C, M, F, G, InstructionSet, Subtables>
+where
+    F: PrimeField,
+    G: CurveGroup<ScalarField = F>,
+    InstructionSet: JoltInstruction + Opcode + IntoEnumIterator + EnumCount,
+    Subtables: LassoSubtable<F> + IntoEnumIterator + EnumCount + From<SubtableId> + Into<usize>,
+{
+    const NUM_SUBTABLES: usize = Subtables::COUNT;
+    const NUM_INSTRUCTIONS: usize = InstructionSet::COUNT;
+
     #[tracing::instrument(skip_all, name = "InstructionLookups::prove_lookups")]
     pub fn prove_lookups(
-        &self,
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        ops: Vec<InstructionSet>,
         generators: &PedersenGenerators<G>,
         transcript: &mut Transcript,
     ) -> (
-        InstructionLookupsProof<F, G, Subtables>,
-        InstructionPolynomials<F, G>,
+        InstructionLookupsProof<C, M, F, G, InstructionSet, Subtables>,
+        InstructionPolynomials<C, F, G>,
         InstructionCommitment<G>,
     ) {
         <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());
 
-        let polynomials = self.polynomialize();
+        let polynomials = Self::polynomialize(preprocessing, &ops);
         let batched_polys = polynomials.batch();
         let commitment = InstructionPolynomials::commit(&batched_polys, generators);
 
@@ -816,12 +909,12 @@ where
         let r_eq = <Transcript as ProofTranscript<G>>::challenge_vector(
             transcript,
             b"Jolt instruction lookups",
-            self.ops.len().log_2(),
+            ops.len().log_2(),
         );
 
         let eq_evals: Vec<F> = EqPolynomial::new(r_eq.to_vec()).evals();
         let sumcheck_claim =
-            Self::compute_sumcheck_claim(&self.ops, &polynomials.E_polys, &eq_evals);
+            Self::compute_sumcheck_claim(preprocessing, &ops, &polynomials.E_polys, &eq_evals);
 
         <Transcript as ProofTranscript<G>>::append_scalar(
             transcript,
@@ -830,12 +923,13 @@ where
         );
 
         let mut eq_poly = DensePolynomial::new(eq_evals);
-        let num_rounds = self.ops.len().log_2();
+        let num_rounds = ops.len().log_2();
 
         // TODO: compartmentalize all primary sumcheck logic
 
         let (primary_sumcheck_proof, r_primary_sumcheck, flag_evals, E_evals) =
             Self::prove_primary_sumcheck(
+                preprocessing,
                 &F::zero(),
                 num_rounds,
                 &mut eq_poly,
@@ -865,10 +959,12 @@ where
             opening_proof: sumcheck_opening_proof,
         };
 
-        let memory_checking = self.prove_memory_checking(&polynomials, &batched_polys, transcript);
+        let memory_checking =
+            Self::prove_memory_checking(preprocessing, &polynomials, &batched_polys, transcript);
 
         (
             InstructionLookupsProof {
+                _instructions: PhantomData,
                 primary_sumcheck,
                 memory_checking,
             },
@@ -878,7 +974,8 @@ where
     }
 
     pub fn verify(
-        proof: InstructionLookupsProof<F, G, Subtables>,
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        proof: InstructionLookupsProof<C, M, F, G, InstructionSet, Subtables>,
         commitment: InstructionCommitment<G>,
         transcript: &mut Transcript,
     ) -> Result<(), ProofVerifyError> {
@@ -916,6 +1013,7 @@ where
         assert_eq!(
             eq_eval
                 * Self::combine_lookups(
+                    preprocessing,
                     &proof.primary_sumcheck.openings.E_poly_openings,
                     &proof.primary_sumcheck.openings.flag_openings,
                 ),
@@ -930,36 +1028,41 @@ where
             transcript,
         )?;
 
-        Self::verify_memory_checking(proof.memory_checking, &commitment, transcript)?;
+        Self::verify_memory_checking(
+            preprocessing,
+            proof.memory_checking,
+            &commitment,
+            transcript,
+        )?;
 
         Ok(())
     }
 
     /// Constructs the polynomials used in the primary sumcheck and memory checking.
     #[tracing::instrument(skip_all, name = "InstructionLookups::polynomialize")]
-    fn polynomialize(&self) -> InstructionPolynomials<F, G> {
-        let m: usize = self.ops.len().next_power_of_two();
+    fn polynomialize(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        ops: &Vec<InstructionSet>,
+    ) -> InstructionPolynomials<C, F, G> {
+        let m: usize = ops.len().next_power_of_two();
 
-        let subtable_lookup_indices: Vec<Vec<usize>> = Self::subtable_lookup_indices(&self.ops);
+        let subtable_lookup_indices: Vec<Vec<usize>> = Self::subtable_lookup_indices(ops);
 
-        let instruction_to_memory_indices_map: Vec<Vec<usize>> = InstructionSet::iter()
-            .map(|op| Self::instruction_to_memory_indices(&op))
-            .collect();
         let polys: Vec<(DensePolynomial<F>, DensePolynomial<F>, DensePolynomial<F>)> = (0
-            ..Self::NUM_MEMORIES)
+            ..preprocessing.num_memories)
             .into_par_iter()
             .map(|memory_index| {
-                let dim_index = Self::memory_to_dimension_index(memory_index);
-                let subtable_index = Self::memory_to_subtable_index(memory_index);
+                let dim_index = preprocessing.memory_to_dimension_index[memory_index];
+                let subtable_index = preprocessing.memory_to_subtable_index[memory_index];
                 let access_sequence: &Vec<usize> = &subtable_lookup_indices[dim_index];
 
                 let mut final_cts_i = vec![0usize; M];
                 let mut read_cts_i = vec![0usize; m];
                 let mut subtable_lookups = vec![F::zero(); m];
 
-                for (j, op) in self.ops.iter().enumerate() {
-                    let memories_used: &Vec<usize> =
-                        &instruction_to_memory_indices_map[op.to_opcode() as usize];
+                for (j, op) in ops.iter().enumerate() {
+                    let memories_used: Vec<usize> =
+                        preprocessing.instruction_to_memory_indices[op.to_opcode() as usize];
                     if memories_used.contains(&memory_index) {
                         let memory_address = access_sequence[j];
                         debug_assert!(memory_address < M);
@@ -968,7 +1071,7 @@ where
                         read_cts_i[j] = counter;
                         final_cts_i[memory_address] = counter + 1;
                         subtable_lookups[j] =
-                            self.materialized_subtables[subtable_index][memory_address];
+                            preprocessing.materialized_subtables[subtable_index][memory_address];
                     }
                 }
 
@@ -1005,7 +1108,7 @@ where
 
         let mut instruction_flag_bitvectors: Vec<Vec<usize>> =
             vec![vec![0usize; m]; Self::NUM_INSTRUCTIONS];
-        for (j, op) in self.ops.iter().enumerate() {
+        for (j, op) in ops.iter().enumerate() {
             let opcode_index = op.to_opcode() as usize;
             instruction_flag_bitvectors[opcode_index][j] = 1;
         }
@@ -1042,6 +1145,7 @@ where
     /// - `transcript`: Fiat-shamir transcript.
     #[tracing::instrument(skip_all, name = "InstructionLookups::prove_primary_sumcheck")]
     fn prove_primary_sumcheck(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
         _claim: &F,
         num_rounds: usize,
         eq_poly: &mut DensePolynomial<F>,
@@ -1052,27 +1156,23 @@ where
     ) -> (SumcheckInstanceProof<F>, Vec<F>, Vec<F>, Vec<F>) {
         // Check all polys are the same size
         let poly_len = eq_poly.len();
-        for index in 0..Self::NUM_MEMORIES {
-            debug_assert_eq!(memory_polys[index].len(), poly_len);
-        }
-        for index in 0..Self::NUM_INSTRUCTIONS {
-            debug_assert_eq!(flag_polys[index].len(), poly_len);
-        }
-
-        let instruction_to_memory_indices_map: Vec<Vec<usize>> = InstructionSet::iter()
-            .map(|op| Self::instruction_to_memory_indices(&op))
-            .collect();
+        memory_polys
+            .iter()
+            .for_each(|E_poly| debug_assert_eq!(E_poly.len(), poly_len));
+        flag_polys
+            .iter()
+            .for_each(|flag_poly| debug_assert_eq!(flag_poly.len(), poly_len));
 
         let mut random_vars: Vec<F> = Vec::with_capacity(num_rounds);
         let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::with_capacity(num_rounds);
         let num_eval_points = degree + 1;
 
         let round_uni_poly = Self::primary_sumcheck_inner_loop(
+            preprocessing,
             &eq_poly,
             &flag_polys,
             &memory_polys,
             num_eval_points,
-            &instruction_to_memory_indices_map,
         );
         compressed_polys.push(round_uni_poly.compress());
         let r_j = Self::update_primary_sumcheck_transcript(round_uni_poly, transcript);
@@ -1094,11 +1194,11 @@ where
 
         for _round in 1..num_rounds {
             let round_uni_poly = Self::primary_sumcheck_inner_loop(
+                preprocessing,
                 &eq_poly,
                 &flag_polys_updated,
                 &memory_polys_updated,
                 num_eval_points,
-                &instruction_to_memory_indices_map,
             );
             compressed_polys.push(round_uni_poly.compress());
             let r_j = Self::update_primary_sumcheck_transcript(round_uni_poly, transcript);
@@ -1125,12 +1225,8 @@ where
 
         // Polys are fully defined so we can just take the first (and only) evaluation
         // let flag_evals = (0..flag_polys.len()).map(|i| flag_polys[i][0]).collect();
-        let flag_evals = (0..flag_polys_updated.len())
-            .map(|i| flag_polys_updated[i][0])
-            .collect();
-        let memory_evals = (0..memory_polys_updated.len())
-            .map(|i| memory_polys_updated[i][0])
-            .collect();
+        let flag_evals = flag_polys_updated.iter().map(|poly| poly[0]).collect();
+        let memory_evals = memory_polys_updated.iter().map(|poly| poly[0]).collect();
 
         (
             SumcheckInstanceProof::new(compressed_polys),
@@ -1142,23 +1238,22 @@ where
 
     #[tracing::instrument(skip_all, name = "InstructionLookups::primary_sumcheck_inner_loop")]
     fn primary_sumcheck_inner_loop(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
         eq_poly: &DensePolynomial<F>,
         flag_polys: &Vec<DensePolynomial<F>>,
         memory_polys: &Vec<DensePolynomial<F>>,
         num_eval_points: usize,
-        instruction_to_memory_indices_map: &Vec<Vec<usize>>,
     ) -> UniPoly<F> {
         let mle_len = eq_poly.len();
         let mle_half = mle_len / 2;
-
-        let evaluate_mles_iterator = (0..mle_half).into_par_iter();
 
         // Loop over half MLE size (size of MLE next round)
         //   - Compute evaluations of eq, flags, E, at p {0, 1, ..., degree}:
         //       eq(p, _boolean_hypercube_), flags(p, _boolean_hypercube_), E(p, _boolean_hypercube_)
         // After: Sum over MLE elements (with combine)
 
-        let evaluations: Vec<F> = evaluate_mles_iterator
+        let evaluations: Vec<F> = (0..mle_half)
+            .into_par_iter()
             .map(|low_index| {
                 let high_index = mle_half + low_index;
 
@@ -1166,7 +1261,7 @@ where
                 let mut multi_flag_evals: Vec<Vec<F>> =
                     vec![vec![F::zero(); Self::NUM_INSTRUCTIONS]; num_eval_points];
                 let mut multi_memory_evals: Vec<Vec<F>> =
-                    vec![vec![F::zero(); Self::NUM_MEMORIES]; num_eval_points];
+                    vec![vec![F::zero(); preprocessing.num_memories]; num_eval_points];
 
                 eq_evals[0] = eq_poly[low_index];
                 eq_evals[1] = eq_poly[high_index];
@@ -1192,7 +1287,7 @@ where
                 }
 
                 // TODO: Some of these intermediates need not be computed if flags is computed
-                for memory_index in 0..Self::NUM_MEMORIES {
+                for memory_index in 0..preprocessing.num_memories {
                     multi_memory_evals[0][memory_index] = memory_polys[memory_index][low_index];
 
                     multi_memory_evals[1][memory_index] = memory_polys[memory_index][high_index];
@@ -1213,8 +1308,8 @@ where
                 let mut inner_sum = vec![F::zero(); num_eval_points];
                 for instruction in InstructionSet::iter() {
                     let instruction_index = instruction.to_opcode() as usize;
-                    let memory_indices: &Vec<usize> =
-                        &instruction_to_memory_indices_map[instruction_index];
+                    let memory_indices =
+                        preprocessing.instruction_to_memory_indices[instruction_index];
 
                     for eval_index in 0..num_eval_points {
                         let flag_eval = multi_flag_evals[eval_index][instruction_index];
@@ -1271,6 +1366,7 @@ where
 
     #[tracing::instrument(skip_all, name = "InstructionLookups::compute_sumcheck_claim")]
     fn compute_sumcheck_claim(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
         ops: &Vec<InstructionSet>,
         E_polys: &Vec<DensePolynomial<F>>,
         eq_evals: &Vec<F>,
@@ -1281,15 +1377,12 @@ where
             E_polys.iter().for_each(|E_i| assert_eq!(E_i.len(), m));
         }
 
-        let instruction_to_memory_indices_map: Vec<Vec<usize>> = InstructionSet::iter()
-            .map(|op| Self::instruction_to_memory_indices(&op))
-            .collect();
-
         let claim = ops
             .par_iter()
             .enumerate()
             .map(|(k, op)| {
-                let memory_indices = &instruction_to_memory_indices_map[op.to_opcode() as usize];
+                let memory_indices =
+                    &preprocessing.instruction_to_memory_indices[op.to_opcode() as usize];
                 let filtered_operands: Vec<F> = memory_indices
                     .iter()
                     .map(|memory_index| E_polys[*memory_index][k])
@@ -1308,14 +1401,19 @@ where
     /// \sum_x \tilde{eq}(r, x) * \sum_i flag_i(x) * g_i(E_1(x), ..., E_\alpha(x))
     /// where `vals` corresponds to E_1, ..., E_\alpha,
     /// and `flags` corresponds to the flag_i's
-    fn combine_lookups(vals: &[F], flags: &[F]) -> F {
-        assert_eq!(vals.len(), Self::NUM_MEMORIES);
+    fn combine_lookups(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        vals: &[F],
+        flags: &[F],
+    ) -> F {
+        assert_eq!(vals.len(), preprocessing.num_memories);
         assert_eq!(flags.len(), Self::NUM_INSTRUCTIONS);
 
         let mut sum = F::zero();
         for instruction in InstructionSet::iter() {
             let instruction_index = instruction.to_opcode() as usize;
-            let memory_indices = Self::instruction_to_memory_indices(&instruction);
+            let memory_indices =
+                preprocessing.instruction_to_memory_indices[instruction.to_opcode() as usize];
             let mut filtered_operands = Vec::with_capacity(memory_indices.len());
             for index in memory_indices {
                 filtered_operands.push(vals[index]);
@@ -1326,6 +1424,8 @@ where
         sum
     }
 
+    // TODO(moodlezoup): fn memory_flags(instruction_flags: &Vec<F>) -> Vec<F>
+
     /// Converts instruction flag values into subtable flag vales. A subtable flag value
     /// can be computed by summing over the instructions that use that subtable: if a given execution step
     /// accesses the subtable, it must be executing exactly one of those instructions.
@@ -1333,9 +1433,9 @@ where
         let mut subtable_flags = vec![F::zero(); Self::NUM_SUBTABLES];
         for (i, instruction) in InstructionSet::iter().enumerate() {
             let instruction_subtables: Vec<Subtables> = instruction
-                .subtables::<F>(C)
+                .subtables::<F>(C, M)
                 .iter()
-                .map(|subtable| Subtables::from(subtable.subtable_id()))
+                .map(|(subtable, _)| Subtables::from(subtable.subtable_id()))
                 .collect();
             for subtable in instruction_subtables {
                 let subtable_index: usize = subtable.into();
@@ -1357,9 +1457,13 @@ where
             .map(|subtable_index| {
                 let mut subtable_poly = DensePolynomial::new(vec![F::zero(); m]);
                 for (i, instruction) in InstructionSet::iter().enumerate() {
-                    if instruction.subtables::<F>(C).iter().any(|subtable| {
-                        Subtables::from(subtable.subtable_id()).into() == subtable_index
-                    }) {
+                    if instruction
+                        .subtables::<F>(C, M)
+                        .iter()
+                        .any(|(subtable, _)| {
+                            Subtables::from(subtable.subtable_id()).into() == subtable_index
+                        })
+                    {
                         // TODO(JOLT-81): Do not DensePolynomial<F>::add_assign to compute this value.
                         subtable_poly += &instruction_flag_polys[i];
                     }
@@ -1368,24 +1472,6 @@ where
             })
             .collect();
         subtable_flag_polys
-    }
-
-    /// Converts an instruction into the memory indices that it "accesses". Each instruction uses some
-    /// subset of `Subtables`, and each subtable in turn maps to some contiguous range of memory indices.
-    fn instruction_to_memory_indices(op: &InstructionSet) -> Vec<usize> {
-        let instruction_subtables: Vec<Subtables> = op
-            .subtables::<F>(C)
-            .iter()
-            .map(|subtable| Subtables::from(subtable.subtable_id()))
-            .collect();
-
-        let mut memory_indices = Vec::with_capacity(C * instruction_subtables.len());
-        for subtable in instruction_subtables {
-            let index: usize = subtable.into();
-            memory_indices.extend((C * index)..(C * (index + 1)));
-        }
-
-        memory_indices
     }
 
     /// Returns the sumcheck polynomial degree for the "primary" sumcheck. Since the primary sumcheck expression
@@ -1397,16 +1483,6 @@ where
             .max()
             .unwrap()
             + 2 // eq and flag
-    }
-
-    /// Materializes all subtables used by this Jolt instance.
-    #[tracing::instrument(skip_all, name = "InstructionLookups.materialize_subtables")]
-    fn materialize_subtables() -> Vec<Vec<F>> {
-        let mut subtables: Vec<Vec<_>> = Vec::with_capacity(Subtables::COUNT);
-        for subtable in Subtables::iter() {
-            subtables.push(subtable.materialize(M));
-        }
-        subtables
     }
 
     /// Converts each instruction in `ops` into its corresponding subtable lookup indices.
@@ -1429,24 +1505,17 @@ where
 
     /// Computes the maximum number of group generators needed to commit to instruction
     /// lookup polynomials using Hyrax, given the maximum trace length.
-    pub fn num_generators(max_trace_length: usize) -> usize {
-        let dim_read_num_vars = (max_trace_length * (C + Self::NUM_MEMORIES)).log_2();
-        let final_num_vars = (M * Self::NUM_MEMORIES).log_2();
+    pub fn num_generators(
+        preprocessing: &InstructionLookupsPreprocessing<F, InstructionSet, Subtables, C, M>,
+        max_trace_length: usize,
+    ) -> usize {
+        let dim_read_num_vars = (max_trace_length * (C + preprocessing.num_memories)).log_2();
+        let final_num_vars = (M * preprocessing.num_memories).log_2();
         let E_flag_num_vars =
-            (max_trace_length * (Self::NUM_MEMORIES + Self::NUM_INSTRUCTIONS)).log_2();
+            (max_trace_length * (preprocessing.num_memories + Self::NUM_INSTRUCTIONS)).log_2();
 
         let max_num_vars = max([dim_read_num_vars, final_num_vars, E_flag_num_vars]).unwrap();
         matrix_dimensions(max_num_vars).1.pow2()
-    }
-
-    /// Maps an index [0, NUM_MEMORIES) -> [0, NUM_SUBTABLES)
-    fn memory_to_subtable_index(i: usize) -> usize {
-        i / C
-    }
-
-    /// Maps an index [0, NUM_MEMORIES) -> [0, C)
-    fn memory_to_dimension_index(i: usize) -> usize {
-        i % C
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/jolt/vm/rv32i_vm.rs
+++ b/jolt-core/src/jolt/vm/rv32i_vm.rs
@@ -14,12 +14,13 @@ use crate::jolt::instruction::{
     blt::BLTInstruction, bltu::BLTUInstruction, bne::BNEInstruction, or::ORInstruction,
     sll::SLLInstruction, slt::SLTInstruction, sltu::SLTUInstruction, sra::SRAInstruction,
     srl::SRLInstruction, sub::SUBInstruction, xor::XORInstruction, JoltInstruction, Opcode,
+    SubtableIndices,
 };
 use crate::jolt::subtable::{
     and::AndSubtable, eq::EqSubtable, eq_abs::EqAbsSubtable, eq_msb::EqMSBSubtable,
     gt_msb::GtMSBSubtable, identity::IdentitySubtable, lt_abs::LtAbsSubtable, ltu::LtuSubtable,
     or::OrSubtable, sll::SllSubtable, sra_sign::SraSignSubtable, srl::SrlSubtable,
-    truncate_overflow::TruncateOverflowSubtable, xor::XorSubtable, LassoSubtable,
+    truncate_overflow::TruncateOverflowSubtable, xor::XorSubtable, LassoSubtable, SubtableId,
 };
 
 /// Generates an enum out of a list of JoltInstruction types. All JoltInstruction methods
@@ -58,8 +59,8 @@ macro_rules! subtable_enum {
         #[enum_dispatch(LassoSubtable<F>)]
         #[derive(EnumCountMacro, EnumIter)]
         pub enum $enum_name<F: PrimeField> { $($alias($struct)),+ }
-        impl<F: PrimeField> From<TypeId> for $enum_name<F> {
-          fn from(subtable_id: TypeId) -> Self {
+        impl<F: PrimeField> From<SubtableId> for $enum_name<F> {
+          fn from(subtable_id: SubtableId) -> Self {
             $(
               if subtable_id == TypeId::of::<$struct>() {
                 $enum_name::from(<$struct>::new())
@@ -197,7 +198,7 @@ mod tests {
         let mut subtable_set: HashSet<_> = HashSet::new();
         for instruction in <RV32IJoltVM as Jolt<_, G1Projective, C, M>>::InstructionSet::iter()
         {
-            for subtable in instruction.subtables::<Fr>(C) {
+            for (subtable, _) in instruction.subtables::<Fr>(C, M) {
                 // panics if subtable cannot be cast to enum variant
                 let _ = <RV32IJoltVM as Jolt<_, G1Projective, C, M>>::Subtables::from(
                     subtable.subtable_id(),

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -178,7 +178,7 @@ where
 
         let multiset_hashes =
             Self::uninterleave_hashes(preprocessing, read_write_hashes, init_final_hashes);
-        Self::check_multiset_equality(preprocessing, &multiset_hashes);
+        // Self::check_multiset_equality(preprocessing, &multiset_hashes);
         multiset_hashes.append_to_transcript::<G>(transcript);
 
         let (read_write_grand_product, r_read_write) =
@@ -198,7 +198,7 @@ where
     /// with the given leaves. Also returns the corresponding multiset hashes for each memory.
     #[tracing::instrument(skip_all, name = "MemoryCheckingProver::read_write_grand_product")]
     fn read_write_grand_product(
-        preprocessing: &T,
+        _preprocessing: &T,
         _polynomials: &Polynomials,
         read_write_leaves: Vec<DensePolynomial<F>>,
     ) -> (BatchedGrandProductCircuit<F>, Vec<F>) {
@@ -221,7 +221,7 @@ where
     /// with the given leaves. Also returns the corresponding multiset hashes for each memory.
     #[tracing::instrument(skip_all, name = "MemoryCheckingProver::init_final_grand_product")]
     fn init_final_grand_product(
-        preprocessing: &T,
+        _preprocessing: &T,
         _polynomials: &Polynomials,
         init_final_leaves: Vec<DensePolynomial<F>>,
     ) -> (BatchedGrandProductCircuit<F>, Vec<F>) {
@@ -241,7 +241,7 @@ where
     }
 
     fn interleave_hashes(
-        preprocessing: &T,
+        _preprocessing: &T,
         multiset_hashes: &MultisetHashes<F>,
     ) -> (Vec<F>, Vec<F>) {
         let read_write_hashes = interleave(
@@ -259,7 +259,7 @@ where
     }
 
     fn uninterleave_hashes(
-        preprocessing: &T,
+        _preprocessing: &T,
         read_write_hashes: Vec<F>,
         init_final_hashes: Vec<F>,
     ) -> MultisetHashes<F> {
@@ -288,7 +288,7 @@ where
         }
     }
 
-    fn check_multiset_equality(preprocessing: &T, multiset_hashes: &MultisetHashes<F>) {
+    fn check_multiset_equality(_preprocessing: &T, multiset_hashes: &MultisetHashes<F>) {
         let num_memories = multiset_hashes.read_hashes.len();
         assert_eq!(multiset_hashes.final_hashes.len(), num_memories);
         assert_eq!(multiset_hashes.write_hashes.len(), num_memories);

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -82,7 +82,10 @@ where
     pub init_final_opening_proof: InitFinalOpenings::Proof,
 }
 
-pub trait MemoryCheckingProver<F, G, Polynomials>
+// Empty struct to represent that no preprocessing data is used.
+pub struct NoPreprocessing;
+
+pub trait MemoryCheckingProver<F, G, Polynomials, T>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
@@ -97,7 +100,7 @@ where
     #[tracing::instrument(skip_all, name = "MemoryCheckingProver::prove_memory_checking")]
     /// Generates a memory checking proof for the given committed polynomials.
     fn prove_memory_checking(
-        &self,
+        preprocessing: &T,
         polynomials: &Polynomials,
         batched_polys: &Polynomials::BatchedPolynomials,
         transcript: &mut Transcript,
@@ -111,7 +114,7 @@ where
             multiset_hashes,
             r_read_write,
             r_init_final,
-        ) = self.prove_grand_products(polynomials, transcript);
+        ) = Self::prove_grand_products(preprocessing, polynomials, transcript);
 
         let read_write_openings = Self::ReadWriteOpenings::open(polynomials, &r_read_write);
         let read_write_opening_proof = Self::ReadWriteOpenings::prove_openings(
@@ -143,7 +146,7 @@ where
     #[tracing::instrument(skip_all, name = "MemoryCheckingProver::prove_grand_products")]
     /// Proves the grand products for the memory checking multisets (init, read, write, final).
     fn prove_grand_products(
-        &self,
+        preprocessing: &T,
         polynomials: &Polynomials,
         transcript: &mut Transcript,
     ) -> (
@@ -166,14 +169,16 @@ where
         <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());
 
         // fka "ProductLayerProof"
-        let (read_write_leaves, init_final_leaves) = self.compute_leaves(polynomials, &gamma, &tau);
+        let (read_write_leaves, init_final_leaves) =
+            Self::compute_leaves(preprocessing, polynomials, &gamma, &tau);
         let (read_write_circuit, read_write_hashes) =
-            self.read_write_grand_product(polynomials, read_write_leaves);
+            Self::read_write_grand_product(preprocessing, polynomials, read_write_leaves);
         let (init_final_circuit, init_final_hashes) =
-            self.init_final_grand_product(polynomials, init_final_leaves);
+            Self::init_final_grand_product(preprocessing, polynomials, init_final_leaves);
 
-        let multiset_hashes = Self::uninterleave_hashes(read_write_hashes, init_final_hashes);
-        Self::check_multiset_equality(&multiset_hashes);
+        let multiset_hashes =
+            Self::uninterleave_hashes(preprocessing, read_write_hashes, init_final_hashes);
+        Self::check_multiset_equality(preprocessing, &multiset_hashes);
         multiset_hashes.append_to_transcript::<G>(transcript);
 
         let (read_write_grand_product, r_read_write) =
@@ -193,7 +198,7 @@ where
     /// with the given leaves. Also returns the corresponding multiset hashes for each memory.
     #[tracing::instrument(skip_all, name = "MemoryCheckingProver::read_write_grand_product")]
     fn read_write_grand_product(
-        &self,
+        preprocessing: &T,
         _polynomials: &Polynomials,
         read_write_leaves: Vec<DensePolynomial<F>>,
     ) -> (BatchedGrandProductCircuit<F>, Vec<F>) {
@@ -216,7 +221,7 @@ where
     /// with the given leaves. Also returns the corresponding multiset hashes for each memory.
     #[tracing::instrument(skip_all, name = "MemoryCheckingProver::init_final_grand_product")]
     fn init_final_grand_product(
-        &self,
+        preprocessing: &T,
         _polynomials: &Polynomials,
         init_final_leaves: Vec<DensePolynomial<F>>,
     ) -> (BatchedGrandProductCircuit<F>, Vec<F>) {
@@ -235,7 +240,10 @@ where
         )
     }
 
-    fn interleave_hashes(multiset_hashes: &MultisetHashes<F>) -> (Vec<F>, Vec<F>) {
+    fn interleave_hashes(
+        preprocessing: &T,
+        multiset_hashes: &MultisetHashes<F>,
+    ) -> (Vec<F>, Vec<F>) {
         let read_write_hashes = interleave(
             multiset_hashes.read_hashes.clone(),
             multiset_hashes.write_hashes.clone(),
@@ -251,6 +259,7 @@ where
     }
 
     fn uninterleave_hashes(
+        preprocessing: &T,
         read_write_hashes: Vec<F>,
         init_final_hashes: Vec<F>,
     ) -> MultisetHashes<F> {
@@ -279,7 +288,7 @@ where
         }
     }
 
-    fn check_multiset_equality(multiset_hashes: &MultisetHashes<F>) {
+    fn check_multiset_equality(preprocessing: &T, multiset_hashes: &MultisetHashes<F>) {
         let num_memories = multiset_hashes.read_hashes.len();
         assert_eq!(multiset_hashes.final_hashes.len(), num_memories);
         assert_eq!(multiset_hashes.write_hashes.len(), num_memories);
@@ -302,7 +311,7 @@ where
     /// one of each type per memory.
     /// Returns: (interleaved read/write leaves, interleaved init/final leaves)
     fn compute_leaves(
-        &self,
+        preprocessing: &T,
         polynomials: &Polynomials,
         gamma: &F,
         tau: &F,
@@ -316,8 +325,8 @@ where
     fn protocol_name() -> &'static [u8];
 }
 
-pub trait MemoryCheckingVerifier<F, G, Polynomials>:
-    MemoryCheckingProver<F, G, Polynomials>
+pub trait MemoryCheckingVerifier<F, G, Polynomials, T>:
+    MemoryCheckingProver<F, G, Polynomials, T>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
@@ -325,6 +334,7 @@ where
 {
     /// Verifies a memory checking proof, given its associated polynomial `commitment`.
     fn verify_memory_checking(
+        preprocessing: &T,
         mut proof: MemoryCheckingProof<
             G,
             Polynomials,
@@ -346,11 +356,11 @@ where
 
         <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());
 
-        Self::check_multiset_equality(&proof.multiset_hashes);
+        Self::check_multiset_equality(preprocessing, &proof.multiset_hashes);
         proof.multiset_hashes.append_to_transcript::<G>(transcript);
 
         let (read_write_hashes, init_final_hashes) =
-            Self::interleave_hashes(&proof.multiset_hashes);
+            Self::interleave_hashes(preprocessing, &proof.multiset_hashes);
 
         let (claims_read_write, r_read_write) = proof
             .read_write_grand_product
@@ -380,6 +390,7 @@ where
             .compute_verifier_openings(&r_init_final);
 
         Self::check_fingerprints(
+            preprocessing,
             claims_read_write,
             claims_init_final,
             &proof.read_write_openings,
@@ -392,17 +403,26 @@ where
     }
 
     /// Computes "read" memory tuples (one per memory) from the given `openings`.
-    fn read_tuples(openings: &Self::ReadWriteOpenings) -> Vec<Self::MemoryTuple>;
+    fn read_tuples(preprocessing: &T, openings: &Self::ReadWriteOpenings)
+        -> Vec<Self::MemoryTuple>;
     /// Computes "write" memory tuples (one per memory) from the given `openings`.
-    fn write_tuples(openings: &Self::ReadWriteOpenings) -> Vec<Self::MemoryTuple>;
+    fn write_tuples(
+        preprocessing: &T,
+        openings: &Self::ReadWriteOpenings,
+    ) -> Vec<Self::MemoryTuple>;
     /// Computes "init" memory tuples (one per memory) from the given `openings`.
-    fn init_tuples(openings: &Self::InitFinalOpenings) -> Vec<Self::MemoryTuple>;
+    fn init_tuples(preprocessing: &T, openings: &Self::InitFinalOpenings)
+        -> Vec<Self::MemoryTuple>;
     /// Computes "final" memory tuples (one per memory) from the given `openings`.
-    fn final_tuples(openings: &Self::InitFinalOpenings) -> Vec<Self::MemoryTuple>;
+    fn final_tuples(
+        preprocessing: &T,
+        openings: &Self::InitFinalOpenings,
+    ) -> Vec<Self::MemoryTuple>;
 
     /// Checks that the claimed multiset hashes (output by grand product) are consistent with the
     /// openings given by `read_write_openings` and `init_final_openings`.
     fn check_fingerprints(
+        preprocessing: &T,
         claims_read_write: Vec<F>,
         claims_init_final: Vec<F>,
         read_write_openings: &Self::ReadWriteOpenings,
@@ -410,26 +430,22 @@ where
         gamma: &F,
         tau: &F,
     ) {
-        let read_hashes: Vec<_> =
-            <Self as MemoryCheckingVerifier<_, _, _>>::read_tuples(read_write_openings)
-                .iter()
-                .map(|tuple| Self::fingerprint(tuple, gamma, tau))
-                .collect();
-        let write_hashes: Vec<_> =
-            <Self as MemoryCheckingVerifier<_, _, _>>::write_tuples(read_write_openings)
-                .iter()
-                .map(|tuple| Self::fingerprint(tuple, gamma, tau))
-                .collect();
-        let init_hashes: Vec<_> =
-            <Self as MemoryCheckingVerifier<_, _, _>>::init_tuples(init_final_openings)
-                .iter()
-                .map(|tuple| Self::fingerprint(tuple, gamma, tau))
-                .collect();
-        let final_hashes: Vec<_> =
-            <Self as MemoryCheckingVerifier<_, _, _>>::final_tuples(init_final_openings)
-                .iter()
-                .map(|tuple| Self::fingerprint(tuple, gamma, tau))
-                .collect();
+        let read_hashes: Vec<_> = Self::read_tuples(preprocessing, read_write_openings)
+            .iter()
+            .map(|tuple| Self::fingerprint(tuple, gamma, tau))
+            .collect();
+        let write_hashes: Vec<_> = Self::write_tuples(preprocessing, read_write_openings)
+            .iter()
+            .map(|tuple| Self::fingerprint(tuple, gamma, tau))
+            .collect();
+        let init_hashes: Vec<_> = Self::init_tuples(preprocessing, init_final_openings)
+            .iter()
+            .map(|tuple| Self::fingerprint(tuple, gamma, tau))
+            .collect();
+        let final_hashes: Vec<_> = Self::final_tuples(preprocessing, init_final_openings)
+            .iter()
+            .map(|tuple| Self::fingerprint(tuple, gamma, tau))
+            .collect();
         assert_eq!(
             read_hashes.len() + write_hashes.len(),
             claims_read_write.len()
@@ -445,7 +461,8 @@ where
             init_hashes,
             final_hashes,
         };
-        let (read_write_hashes, init_final_hashes) = Self::interleave_hashes(&multiset_hashes);
+        let (read_write_hashes, init_final_hashes) =
+            Self::interleave_hashes(preprocessing, &multiset_hashes);
 
         for (claim, fingerprint) in zip(claims_read_write, read_write_hashes) {
             assert_eq!(claim, fingerprint);
@@ -510,13 +527,16 @@ mod tests {
             fn batch(&self) -> Self::BatchedPolynomials {
                 unimplemented!()
             }
-            fn commit(_batched_polys: &Self::BatchedPolynomials, generators: &PedersenGenerators<EdwardsProjective>) -> Self::Commitment {
+            fn commit(
+                _batched_polys: &Self::BatchedPolynomials,
+                generators: &PedersenGenerators<EdwardsProjective>,
+            ) -> Self::Commitment {
                 unimplemented!()
             }
         }
 
         struct TestProver {}
-        impl MemoryCheckingProver<Fr, EdwardsProjective, NormalMems> for TestProver {
+        impl MemoryCheckingProver<Fr, EdwardsProjective, NormalMems, ()> for TestProver {
             type ReadWriteOpenings = FakeOpeningProof;
             type InitFinalOpenings = FakeOpeningProof;
 
@@ -643,7 +663,7 @@ mod tests {
         );
         multiset_hashes.append_to_transcript::<EdwardsProjective>(&mut transcript);
         let (interleaved_read_write_hashes, interleaved_init_final_hashes) =
-            TestProver::interleave_hashes(&multiset_hashes);
+            prover.interleave_hashes(&multiset_hashes);
 
         let (_claims_rw, r_rw_verify) = proof_rw
             .verify::<EdwardsProjective, _>(&interleaved_read_write_hashes, &mut transcript);
@@ -710,13 +730,16 @@ mod tests {
             fn batch(&self) -> Self::BatchedPolynomials {
                 unimplemented!()
             }
-            fn commit(_batched_polys: &Self::BatchedPolynomials, generators: &PedersenGenerators<EdwardsProjective>) -> Self::Commitment {
+            fn commit(
+                _batched_polys: &Self::BatchedPolynomials,
+                generators: &PedersenGenerators<EdwardsProjective>,
+            ) -> Self::Commitment {
                 unimplemented!()
             }
         }
 
         struct TestProver {}
-        impl MemoryCheckingProver<Fr, EdwardsProjective, Polys> for TestProver {
+        impl MemoryCheckingProver<Fr, EdwardsProjective, Polys, ()> for TestProver {
             type ReadWriteOpenings = FakeOpeningProof;
             type InitFinalOpenings = FakeOpeningProof;
 
@@ -892,7 +915,7 @@ mod tests {
         );
         multiset_hashes.append_to_transcript::<EdwardsProjective>(&mut transcript);
         let (interleaved_read_write_hashes, interleaved_init_final_hashes) =
-            TestProver::interleave_hashes(&multiset_hashes);
+            prover.interleave_hashes(&multiset_hashes);
 
         let (_claims_rw, r_rw_verify) = proof_rw
             .verify::<EdwardsProjective, _>(&interleaved_read_write_hashes, &mut transcript);
@@ -956,13 +979,16 @@ mod tests {
             fn batch(&self) -> Self::BatchedPolynomials {
                 unimplemented!()
             }
-            fn commit(_batched_polys: &Self::BatchedPolynomials, generators: &PedersenGenerators<EdwardsProjective>) -> Self::Commitment {
+            fn commit(
+                _batched_polys: &Self::BatchedPolynomials,
+                generators: &PedersenGenerators<EdwardsProjective>,
+            ) -> Self::Commitment {
                 unimplemented!()
             }
         }
 
         struct TestProver {}
-        impl MemoryCheckingProver<Fr, EdwardsProjective, FlagPolys> for TestProver {
+        impl MemoryCheckingProver<Fr, EdwardsProjective, FlagPolys, ()> for TestProver {
             type ReadWriteOpenings = FakeOpeningProof;
             type InitFinalOpenings = FakeOpeningProof;
 
@@ -1195,7 +1221,7 @@ mod tests {
         );
         multiset_hashes.append_to_transcript::<EdwardsProjective>(&mut transcript);
         let (interleaved_read_write_hashes, interleaved_init_final_hashes) =
-            TestProver::interleave_hashes(&multiset_hashes);
+            prover.interleave_hashes(&multiset_hashes);
 
         let (_claims_rw, r_rw_verify) = proof_rw
             .verify::<EdwardsProjective, _>(&interleaved_read_write_hashes, &mut transcript);

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -410,7 +410,7 @@ where
     Instruction: JoltInstruction + Default + Sync,
 {
     fn read_tuples(
-        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        _preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
         openings: &Self::ReadWriteOpenings,
     ) -> Vec<Self::MemoryTuple> {
         (0..Self::num_memories())
@@ -425,7 +425,7 @@ where
             .collect()
     }
     fn write_tuples(
-        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        _preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
         openings: &Self::ReadWriteOpenings,
     ) -> Vec<Self::MemoryTuple> {
         (0..Self::num_memories())
@@ -440,7 +440,7 @@ where
             .collect()
     }
     fn init_tuples(
-        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        _preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
         openings: &Self::InitFinalOpenings,
     ) -> Vec<Self::MemoryTuple> {
         let a_init = openings.a_init_final.unwrap();
@@ -457,7 +457,7 @@ where
             .collect()
     }
     fn final_tuples(
-        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        _preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
         openings: &Self::InitFinalOpenings,
     ) -> Vec<Self::MemoryTuple> {
         let a_init = openings.a_init_final.unwrap();
@@ -602,7 +602,7 @@ where
         );
         let eq: DensePolynomial<F> =
             DensePolynomial::new(EqPolynomial::new(r_primary_sumcheck.to_vec()).evals());
-        let sumcheck_claim: F = Self::compute_primary_sumcheck_claim(&polynomials, &eq, M);
+        let sumcheck_claim: F = Self::compute_primary_sumcheck_claim(&polynomials, &eq);
 
         <Transcript as ProofTranscript<G>>::append_scalar(
             transcript,
@@ -663,7 +663,6 @@ where
         preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
         proof: SurgeProof<F, G, Instruction, C, M>,
         transcript: &mut Transcript,
-        M: usize,
     ) -> Result<(), ProofVerifyError> {
         <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());
         let instruction = Instruction::default();
@@ -797,11 +796,7 @@ where
     }
 
     #[tracing::instrument(skip_all, name = "Surge::compute_primary_sumcheck_claim")]
-    fn compute_primary_sumcheck_claim(
-        polys: &SurgePolys<F, G>,
-        eq: &DensePolynomial<F>,
-        M: usize,
-    ) -> F {
+    fn compute_primary_sumcheck_claim(polys: &SurgePolys<F, G>, eq: &DensePolynomial<F>) -> F {
         let g_operands = &polys.E_polys;
         let hypercube_size = g_operands[0].len();
         g_operands
@@ -850,7 +845,7 @@ mod tests {
         );
 
         let mut transcript = Transcript::new(b"test_transcript");
-        SurgeProof::verify(&preprocessing, proof, &mut transcript, M).expect("should work");
+        SurgeProof::verify(&preprocessing, proof, &mut transcript).expect("should work");
     }
 
     #[test]
@@ -874,6 +869,6 @@ mod tests {
         );
 
         let mut transcript = Transcript::new(b"test_transcript");
-        SurgeProof::verify(&preprocessing, proof, &mut transcript, M).expect("should work");
+        SurgeProof::verify(&preprocessing, proof, &mut transcript).expect("should work");
     }
 }

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -231,7 +231,7 @@ where
     }
 }
 
-pub struct SurgeFinalOpenings<F, Instruction, const C: usize>
+pub struct SurgeFinalOpenings<F, Instruction, const C: usize, const M: usize>
 where
     F: PrimeField,
     Instruction: JoltInstruction + Default,
@@ -242,8 +242,8 @@ where
     v_init_final: Option<Vec<F>>, // Computed by verifier
 }
 
-impl<F, G, Instruction, const C: usize> StructuredOpeningProof<F, G, SurgePolys<F, G>>
-    for SurgeFinalOpenings<F, Instruction, C>
+impl<F, G, Instruction, const C: usize, const M: usize>
+    StructuredOpeningProof<F, G, SurgePolys<F, G>> for SurgeFinalOpenings<F, Instruction, C, M>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
@@ -285,9 +285,9 @@ where
             Some(IdentityPolynomial::new(opening_point.len()).evaluate(opening_point));
         self.v_init_final = Some(
             Instruction::default()
-                .subtables(C)
+                .subtables(C, M)
                 .iter()
-                .map(|subtable| subtable.evaluate_mle(opening_point))
+                .map(|(subtable, _)| subtable.evaluate_mle(opening_point))
                 .collect(),
         );
     }
@@ -308,15 +308,16 @@ where
     }
 }
 
-impl<F, G, Instruction, const C: usize> MemoryCheckingProver<F, G, SurgePolys<F, G>>
-    for Surge<F, G, Instruction, C>
+impl<F, G, Instruction, const C: usize, const M: usize>
+    MemoryCheckingProver<F, G, SurgePolys<F, G>, SurgePreprocessing<F, Instruction, C, M>>
+    for SurgeProof<F, G, Instruction, C, M>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
     Instruction: JoltInstruction + Default + Sync,
 {
     type ReadWriteOpenings = SurgeReadWriteOpenings<F>;
-    type InitFinalOpenings = SurgeFinalOpenings<F, Instruction, C>;
+    type InitFinalOpenings = SurgeFinalOpenings<F, Instruction, C, M>;
 
     fn fingerprint(inputs: &(F, F, F), gamma: &F, tau: &F) -> F {
         let (a, v, t) = *inputs;
@@ -325,18 +326,19 @@ where
 
     #[tracing::instrument(skip_all, name = "Surge::compute_leaves")]
     fn compute_leaves(
-        &self,
+        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
         polynomials: &SurgePolys<F, G>,
         gamma: &F,
         tau: &F,
     ) -> (Vec<DensePolynomial<F>>, Vec<DensePolynomial<F>>) {
         let gamma_squared = gamma.square();
+        let num_lookups = polynomials.dim[0].len();
 
         let read_write_leaves = (0..Self::num_memories())
             .into_par_iter()
             .flat_map_iter(|memory_index| {
                 let dim_index = Self::memory_to_dimension_index(memory_index);
-                let read_fingerprints: Vec<F> = (0..self.num_lookups)
+                let read_fingerprints: Vec<F> = (0..num_lookups)
                     .map(|i| {
                         mul_0_1_optimized(&polynomials.read_cts[dim_index][i], &gamma_squared)
                             + mul_0_1_optimized(&polynomials.E_polys[memory_index][i], gamma)
@@ -362,11 +364,13 @@ where
                 let dim_index = Self::memory_to_dimension_index(memory_index);
                 let subtable_index = Self::memory_to_subtable_index(memory_index);
                 // TODO(moodlezoup): Only need one init polynomial per subtable
-                let init_fingerprints: Vec<F> = (0..self.M)
+                let init_fingerprints: Vec<F> = (0..M)
                     .map(|i| {
                         // 0 * gamma^2 +
-                        mul_0_1_optimized(&self.materialized_subtables[subtable_index][i], gamma)
-                            + F::from_u64(i as u64).unwrap()
+                        mul_0_1_optimized(
+                            &preprocessing.materialized_subtables[subtable_index][i],
+                            gamma,
+                        ) + F::from_u64(i as u64).unwrap()
                             - *tau
                     })
                     .collect();
@@ -397,14 +401,18 @@ where
     }
 }
 
-impl<F, G, Instruction, const C: usize> MemoryCheckingVerifier<F, G, SurgePolys<F, G>>
-    for Surge<F, G, Instruction, C>
+impl<F, G, Instruction, const C: usize, const M: usize>
+    MemoryCheckingVerifier<F, G, SurgePolys<F, G>, SurgePreprocessing<F, Instruction, C, M>>
+    for SurgeProof<F, G, Instruction, C, M>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
     Instruction: JoltInstruction + Default + Sync,
 {
-    fn read_tuples(openings: &Self::ReadWriteOpenings) -> Vec<Self::MemoryTuple> {
+    fn read_tuples(
+        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        openings: &Self::ReadWriteOpenings,
+    ) -> Vec<Self::MemoryTuple> {
         (0..Self::num_memories())
             .map(|memory_index| {
                 let dim_index = Self::memory_to_dimension_index(memory_index);
@@ -416,7 +424,10 @@ where
             })
             .collect()
     }
-    fn write_tuples(openings: &Self::ReadWriteOpenings) -> Vec<Self::MemoryTuple> {
+    fn write_tuples(
+        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        openings: &Self::ReadWriteOpenings,
+    ) -> Vec<Self::MemoryTuple> {
         (0..Self::num_memories())
             .map(|memory_index| {
                 let dim_index = Self::memory_to_dimension_index(memory_index);
@@ -428,7 +439,10 @@ where
             })
             .collect()
     }
-    fn init_tuples(openings: &Self::InitFinalOpenings) -> Vec<Self::MemoryTuple> {
+    fn init_tuples(
+        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        openings: &Self::InitFinalOpenings,
+    ) -> Vec<Self::MemoryTuple> {
         let a_init = openings.a_init_final.unwrap();
         let v_init = openings.v_init_final.as_ref().unwrap();
 
@@ -442,7 +456,10 @@ where
             })
             .collect()
     }
-    fn final_tuples(openings: &Self::InitFinalOpenings) -> Vec<Self::MemoryTuple> {
+    fn final_tuples(
+        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        openings: &Self::InitFinalOpenings,
+    ) -> Vec<Self::MemoryTuple> {
         let a_init = openings.a_init_final.unwrap();
         let v_init = openings.v_init_final.as_ref().unwrap();
 
@@ -467,22 +484,16 @@ pub struct SurgePrimarySumcheck<F: PrimeField, G: CurveGroup<ScalarField = F>> {
     opening_proof: BatchedPolynomialOpeningProof<G>,
 }
 
-pub struct Surge<F, G, Instruction, const C: usize>
+pub struct SurgePreprocessing<F, Instruction, const C: usize, const M: usize>
 where
     F: PrimeField,
-    G: CurveGroup<ScalarField = F>,
-    Instruction: JoltInstruction + Default + Sync,
+    Instruction: JoltInstruction + Default,
 {
-    _field: PhantomData<F>,
-    _group: PhantomData<G>,
     _instruction: PhantomData<Instruction>,
-    ops: Vec<Instruction>,
     materialized_subtables: Vec<Vec<F>>,
-    num_lookups: usize,
-    M: usize,
 }
 
-pub struct SurgeProof<F, G, Instruction, const C: usize>
+pub struct SurgeProof<F, G, Instruction, const C: usize, const M: usize>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
@@ -498,41 +509,42 @@ where
         G,
         SurgePolys<F, G>,
         SurgeReadWriteOpenings<F>,
-        SurgeFinalOpenings<F, Instruction, C>,
+        SurgeFinalOpenings<F, Instruction, C, M>,
     >,
 }
 
-impl<F, G, Instruction, const C: usize> Surge<F, G, Instruction, C>
+impl<F, Instruction, const C: usize, const M: usize> SurgePreprocessing<F, Instruction, C, M>
+where
+    F: PrimeField,
+    Instruction: JoltInstruction + Default + Sync,
+{
+    #[tracing::instrument(skip_all, name = "Surge::preprocess")]
+    pub fn preprocess() -> Self {
+        let instruction = Instruction::default();
+
+        let materialized_subtables = instruction
+            .subtables(C, M)
+            .par_iter()
+            .map(|(subtable, _)| subtable.materialize(M))
+            .collect();
+
+        Self {
+            _instruction: PhantomData,
+            materialized_subtables,
+        }
+    }
+}
+
+impl<F, G, Instruction, const C: usize, const M: usize> SurgeProof<F, G, Instruction, C, M>
 where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
     Instruction: JoltInstruction + Default + Sync,
 {
+    #[tracing::instrument(skip_all, name = "Surge::preprocess")]
+
     fn num_memories() -> usize {
-        C * Instruction::default().subtables::<F>(C).len()
-    }
-
-    #[tracing::instrument(skip_all, name = "Surge::new")]
-    // TODO(moodlezoup): we can turn M back into a const generic
-    pub fn new(ops: Vec<Instruction>, M: usize) -> Self {
-        let num_lookups = ops.len().next_power_of_two();
-        let instruction = Instruction::default();
-
-        let materialized_subtables = instruction
-            .subtables(C)
-            .par_iter()
-            .map(|subtable| subtable.materialize(M))
-            .collect();
-
-        Self {
-            _field: PhantomData,
-            _group: PhantomData,
-            _instruction: PhantomData,
-            ops,
-            materialized_subtables,
-            num_lookups,
-            M,
-        }
+        C * Instruction::default().subtables::<F>(C, M).len()
     }
 
     /// Maps an index [0, NUM_MEMORIES) -> [0, NUM_SUBTABLES)
@@ -551,7 +563,7 @@ where
 
     /// Computes the maximum number of group generators needed to commit to Surge polynomials
     /// using Hyrax, given `M` and the maximum number of lookups.
-    pub fn num_generators(M: usize, max_num_lookups: usize) -> usize {
+    pub fn num_generators(max_num_lookups: usize) -> usize {
         let dim_read_num_vars = (max_num_lookups * 2 * C).log_2();
         let final_num_vars = (M * C).log_2();
         let E_num_vars = (max_num_lookups * Self::num_memories()).log_2();
@@ -562,16 +574,22 @@ where
     }
 
     #[tracing::instrument(skip_all, name = "Surge::prove")]
-    pub fn prove(&self, transcript: &mut Transcript) -> SurgeProof<F, G, Instruction, C> {
+    pub fn prove(
+        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        ops: Vec<Instruction>,
+        transcript: &mut Transcript,
+    ) -> Self {
         <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());
 
+        let num_lookups = ops.len().next_power_of_two();
+        let polynomials = Self::construct_polys(preprocessing, &ops);
+        let batched_polys: BatchedSurgePolynomials<F> = polynomials.batch();
         // TODO(sragss): Move upstream
-        let polynomials = self.construct_polys();
-        let batched_polys = polynomials.batch();
         let pedersen_generators =
-            PedersenGenerators::new(Self::num_generators(self.M, self.num_lookups), b"LassoV1");
+            PedersenGenerators::new(Self::num_generators(num_lookups), b"LassoV1");
         let commitment = SurgePolys::commit(&batched_polys, &pedersen_generators);
-        let num_rounds = self.num_lookups.log_2();
+
+        let num_rounds = num_lookups.log_2();
         let instruction = Instruction::default();
 
         // TODO(sragss): Commit some of this stuff to transcript?
@@ -584,7 +602,7 @@ where
         );
         let eq: DensePolynomial<F> =
             DensePolynomial::new(EqPolynomial::new(r_primary_sumcheck.to_vec()).evals());
-        let sumcheck_claim: F = Self::compute_primary_sumcheck_claim(&polynomials, &eq, self.M);
+        let sumcheck_claim: F = Self::compute_primary_sumcheck_claim(&polynomials, &eq, M);
 
         <Transcript as ProofTranscript<G>>::append_scalar(
             transcript,
@@ -597,7 +615,7 @@ where
         let combine_lookups_eq = |vals: &[F]| -> F {
             let vals_no_eq: &[F] = &vals[0..(vals.len() - 1)];
             let eq = vals[vals.len() - 1];
-            instruction.combine_lookups(vals_no_eq, C, self.M) * eq
+            instruction.combine_lookups(vals_no_eq, C, M) * eq
         };
 
         let (primary_sumcheck_proof, r_z, _) =
@@ -627,7 +645,12 @@ where
             opening_proof: sumcheck_opening_proof,
         };
 
-        let memory_checking = self.prove_memory_checking(&polynomials, &batched_polys, transcript);
+        let memory_checking = SurgeProof::prove_memory_checking(
+            &preprocessing,
+            &polynomials,
+            &batched_polys,
+            transcript,
+        );
 
         SurgeProof {
             commitment,
@@ -637,7 +660,8 @@ where
     }
 
     pub fn verify(
-        proof: SurgeProof<F, G, Instruction, C>,
+        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        proof: SurgeProof<F, G, Instruction, C, M>,
         transcript: &mut Transcript,
         M: usize,
     ) -> Result<(), ProofVerifyError> {
@@ -680,24 +704,33 @@ where
             transcript,
         )?;
 
-        Self::verify_memory_checking(proof.memory_checking, &proof.commitment, transcript)
+        Self::verify_memory_checking(
+            preprocessing,
+            proof.memory_checking,
+            &proof.commitment,
+            transcript,
+        )
     }
 
     #[tracing::instrument(skip_all, name = "Surge::construct_polys")]
-    fn construct_polys(&self) -> SurgePolys<F, G> {
-        let mut dim_usize: Vec<Vec<usize>> = vec![vec![0; self.num_lookups]; C];
+    fn construct_polys(
+        preprocessing: &SurgePreprocessing<F, Instruction, C, M>,
+        ops: &Vec<Instruction>,
+    ) -> SurgePolys<F, G> {
+        let num_lookups = ops.len().next_power_of_two();
+        let mut dim_usize: Vec<Vec<usize>> = vec![vec![0; num_lookups]; C];
 
-        let mut read_cts = vec![vec![0usize; self.num_lookups]; C];
-        let mut final_cts = vec![vec![0usize; self.M]; C];
-        let log_M = ark_std::log2(self.M) as usize;
+        let mut read_cts = vec![vec![0usize; num_lookups]; C];
+        let mut final_cts = vec![vec![0usize; M]; C];
+        let log_M = ark_std::log2(M) as usize;
 
-        for (op_index, op) in self.ops.iter().enumerate() {
+        for (op_index, op) in ops.iter().enumerate() {
             let access_sequence = op.to_indices(C, log_M);
             assert_eq!(access_sequence.len(), C);
 
             for dimension_index in 0..C {
                 let memory_address = access_sequence[dimension_index];
-                debug_assert!(memory_address < self.M);
+                debug_assert!(memory_address < M);
 
                 dim_usize[dimension_index][op_index] = memory_address;
 
@@ -712,7 +745,7 @@ where
         // in zeros for read_cts and final_cts as this implicitly specifies a read at address 0. The prover
         // and verifier plumbing assume write_ts(r) = read_ts(r) + 1. This will not hold unless we update
         // the final_cts for these phantom reads.
-        for fake_ops_index in self.ops.len()..self.num_lookups {
+        for fake_ops_index in ops.len()..num_lookups {
             for dimension_index in 0..C {
                 let memory_address = 0;
                 let ts = final_cts[dimension_index][memory_address];
@@ -738,13 +771,13 @@ where
         // Construct E
         let mut E_i_evals = Vec::with_capacity(Self::num_memories());
         for E_index in 0..Self::num_memories() {
-            let mut E_evals = Vec::with_capacity(self.num_lookups);
-            for op_index in 0..self.num_lookups {
+            let mut E_evals = Vec::with_capacity(num_lookups);
+            for op_index in 0..num_lookups {
                 let dimension_index = Self::memory_to_dimension_index(E_index);
                 let subtable_index = Self::memory_to_subtable_index(E_index);
 
                 let eval_index = dim_usize[dimension_index][op_index];
-                let eval = self.materialized_subtables[subtable_index][eval_index];
+                let eval = preprocessing.materialized_subtables[subtable_index][eval_index];
                 E_evals.push(eval);
             }
             E_i_evals.push(E_evals);
@@ -793,8 +826,8 @@ where
 mod tests {
     use merlin::Transcript;
 
-    use super::Surge;
-    use crate::jolt::instruction::xor::XORInstruction;
+    use super::SurgePreprocessing;
+    use crate::{jolt::instruction::xor::XORInstruction, lasso::surge::SurgeProof};
     use ark_curve25519::{EdwardsProjective, Fr};
 
     #[test]
@@ -809,12 +842,15 @@ mod tests {
         const M: usize = 1 << 8;
 
         let mut transcript = Transcript::new(b"test_transcript");
-        let surge = <Surge<Fr, EdwardsProjective, XORInstruction, C>>::new(ops, M);
-        let proof = surge.prove(&mut transcript);
+        let preprocessing = SurgePreprocessing::preprocess();
+        let proof = SurgeProof::<Fr, EdwardsProjective, XORInstruction, C, M>::prove(
+            &preprocessing,
+            ops,
+            &mut transcript,
+        );
 
         let mut transcript = Transcript::new(b"test_transcript");
-        <Surge<Fr, EdwardsProjective, XORInstruction, C>>::verify(proof, &mut transcript, M)
-            .expect("should work");
+        SurgeProof::verify(&preprocessing, proof, &mut transcript, M).expect("should work");
     }
 
     #[test]
@@ -830,11 +866,14 @@ mod tests {
         const M: usize = 1 << 8;
 
         let mut transcript = Transcript::new(b"test_transcript");
-        let surge = <Surge<Fr, EdwardsProjective, XORInstruction, C>>::new(ops, M);
-        let proof = surge.prove(&mut transcript);
+        let preprocessing = SurgePreprocessing::preprocess();
+        let proof = SurgeProof::<Fr, EdwardsProjective, XORInstruction, C, M>::prove(
+            &preprocessing,
+            ops,
+            &mut transcript,
+        );
 
         let mut transcript = Transcript::new(b"test_transcript");
-        <Surge<Fr, EdwardsProjective, XORInstruction, C>>::verify(proof, &mut transcript, M)
-            .expect("should work");
+        SurgeProof::verify(&preprocessing, proof, &mut transcript, M).expect("should work");
     }
 }


### PR DESCRIPTION
Before:
- Instructions are mapped to the set of subtable types via the `subtables` method
- Each subtable type is mapped to `C = 4` "memories" (in the sense of offline memory checking), one per "chunk" of the lookup index
- ...which means each instruction is mapped to `C * |subtables|` memories, or `2 * C * |subtables|` read/write grand products

However, for many instructions, we don't need to access every subtable type at all `C` index chunks –– e.g. we only care about the `EqMsbSubtable` value at the 0th index chunk, not 1..C. This means that many of the `C * |subtables|` memories are effectively unused. 

This PR makes the changes necessary to eliminate these unused memories –– the `subtables` method now returns a pair (subtable type, chunk indices) for each subtable type used. `instruction_lookups.rs` is then modified to only instantiate one memory per unique (subtable type, chunk index) pair across the instruction set. 

Tangentially, this PR also introduces a "preprocessing" type parameter to the `MemoryCheckingProver` and `MemoryCheckingVerifier` traits to thread the instruction x subtable x memory mappings through to the functions that need them. This also allows us to move `materialize_subtables` outside of `Jolt::prove`