### PR TITLE
Feat/reshape commitments

### DIFF
--- a/EngineeringOverview.md
+++ b/EngineeringOverview.md
@@ -87,7 +87,7 @@ Run a generic `SumcheckInstanceProof::prove_arbitrary` assuming the lookup polyn
 
 ### 3. Verifier checks $v_{E_{i}} \stackrel{?}{=} E_{i}(r_z)$
 
-`BatchedPolynomialOpeningProof::prove`: Create the combined opening proof from the dense PCS.
+`ConcatenatedPolynomialOpeningProof::prove`: Create the combined opening proof from the dense PCS.
 
 ### 4. Check $E_i \stackrel{?}{=} T_i[\text{dim}_i(j)] \ \forall j \in \{0,1\}^{log(s)}$
 

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -4,3 +4,4 @@ pub const REGISTER_START_ADDRESS: usize = 0;
 pub const RAM_START_ADDRESS: u64 = 0x80000000;
 pub const BYTES_PER_INSTRUCTION: usize = 4;
 pub const MEMORY_OPS_PER_INSTRUCTION: usize = 7;
+pub const NUM_R1CS_POLYS: usize = 82;

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -23,8 +23,8 @@ use crate::{
         identity_poly::IdentityPolynomial,
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
     },
-    subprotocols::batched_commitment::{
-        BatchedPolynomialCommitment, BatchedPolynomialOpeningProof,
+    subprotocols::concatenated_commitment::{
+        ConcatenatedPolynomialCommitment, ConcatenatedPolynomialOpeningProof,
     },
     utils::{errors::ProofVerifyError, is_power_of_two, math::Math},
 };
@@ -441,7 +441,7 @@ pub struct BytecodeCommitment<G: CurveGroup> {
 
     // Combined commitment for:
     // - t_final, v_init_final
-    pub init_final_commitments: BatchedPolynomialCommitment<G>,
+    pub init_final_commitments: ConcatenatedPolynomialCommitment<G>,
 }
 
 impl<F, G> BatchablePolynomials<G> for BytecodePolynomials<F, G>
@@ -734,7 +734,7 @@ where
         ];
         combined_openings.extend(openings.v_read_write_openings.iter());
 
-        BatchedPolynomialOpeningProof::prove(
+        ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.combined_read_write,
             &commitment.read_write_commitments,
             &opening_point,
@@ -802,7 +802,7 @@ where
     ) -> Self::Proof {
         let mut combined_openings: Vec<F> = vec![openings.t_final];
         combined_openings.extend(openings.v_init_final.iter());
-        BatchedPolynomialOpeningProof::prove(
+        ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.combined_init_final,
             &commitment.init_final_commitments,
             &opening_point,

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -711,6 +711,7 @@ where
     #[tracing::instrument(skip_all, name = "BytecodeReadWriteOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedBytecodePolynomials<F>,
+        commitment: &BytecodeCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
@@ -723,6 +724,7 @@ where
 
         BatchedPolynomialOpeningProof::prove(
             &polynomials.combined_read_write,
+            &commitment.read_write_commitments,
             &opening_point,
             &combined_openings,
             transcript,
@@ -781,6 +783,7 @@ where
     #[tracing::instrument(skip_all, name = "BytecodeInitFinalOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedBytecodePolynomials<F>,
+        commitment: &BytecodeCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
@@ -789,6 +792,7 @@ where
         combined_openings.extend(openings.v_init_final.iter());
         BatchedPolynomialOpeningProof::prove(
             &polynomials.combined_init_final,
+            &commitment.init_final_commitments,
             &opening_point,
             &combined_openings,
             transcript,
@@ -905,6 +909,7 @@ mod tests {
             &NoPreprocessing,
             &polys,
             &batched_polys,
+            &commitments,
             &mut transcript,
         );
 
@@ -941,8 +946,13 @@ mod tests {
 
         let mut transcript = Transcript::new(b"test_transcript");
 
-        let proof =
-            BytecodeProof::prove_memory_checking(&NoPreprocessing, &polys, &batch, &mut transcript);
+        let proof = BytecodeProof::prove_memory_checking(
+            &NoPreprocessing,
+            &polys,
+            &batch,
+            &commitments,
+            &mut transcript,
+        );
 
         let mut transcript = Transcript::new(b"test_transcript");
         BytecodeProof::verify_memory_checking(

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, marker::PhantomData};
 use crate::jolt::trace::{rv::RVTraceRow, JoltProvableTrace};
 use crate::lasso::memory_checking::NoPreprocessing;
 use crate::poly::eq_poly::EqPolynomial;
-use crate::poly::hyrax::matrix_dimensions;
+use crate::poly::hyrax::square_matrix_dimensions;
 use crate::poly::pedersen::PedersenGenerators;
 use common::constants::{BYTES_PER_INSTRUCTION, RAM_START_ADDRESS, REGISTER_COUNT};
 use common::RV32IM;
@@ -417,7 +417,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> BytecodePolynomials<F, G> {
         // t_final, v_init_final (opcode, rs1, rs2, rd, imm)
         let init_final_num_vars = (max_bytecode_size * 6).log_2();
         let max_num_vars = std::cmp::max(read_write_num_vars, init_final_num_vars);
-        matrix_dimensions(max_num_vars).1.pow2()
+        square_matrix_dimensions(max_num_vars).1
     }
 }
 

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -436,9 +436,9 @@ pub struct BytecodeCommitment<G: CurveGroup> {
     read_write_generators: HyraxGenerators<NUM_R1CS_POLYS, G>,
     pub a_read_write: HyraxCommitment<NUM_R1CS_POLYS, G>,
     pub v_opcode: HyraxCommitment<NUM_R1CS_POLYS, G>,
+    pub v_rd: HyraxCommitment<NUM_R1CS_POLYS, G>,
     pub v_rs1: HyraxCommitment<NUM_R1CS_POLYS, G>,
     pub v_rs2: HyraxCommitment<NUM_R1CS_POLYS, G>,
-    pub v_rd: HyraxCommitment<NUM_R1CS_POLYS, G>,
     pub v_imm: HyraxCommitment<NUM_R1CS_POLYS, G>,
     pub t_read: HyraxCommitment<NUM_R1CS_POLYS, G>,
 
@@ -483,12 +483,12 @@ where
             batched_polys.a_read_write.get_num_vars(),
             pedersen_generators,
         );
-        let [a_read_write, v_opcode, v_rs1, v_rs2, v_rd, v_imm, t_read] = [
+        let [a_read_write, v_opcode, v_rd, v_rs1, v_rs2, v_imm, t_read] = [
             &batched_polys.a_read_write,
             &batched_polys.v_read_write.opcode,
+            &batched_polys.v_read_write.rd,
             &batched_polys.v_read_write.rs1,
             &batched_polys.v_read_write.rs2,
-            &batched_polys.v_read_write.rd,
             &batched_polys.v_read_write.imm,
             &batched_polys.t_read,
         ]
@@ -506,9 +506,9 @@ where
             read_write_generators,
             a_read_write,
             v_opcode,
+            v_rd,
             v_rs1,
             v_rs2,
-            v_rd,
             v_imm,
             t_read,
             init_final_commitments,
@@ -748,12 +748,12 @@ where
         BatchedHyraxOpeningProof::prove(
             &[
                 &polynomials.a_read_write,
+                &polynomials.t_read,
                 &polynomials.v_read_write.opcode,
+                &polynomials.v_read_write.rd,
                 &polynomials.v_read_write.rs1,
                 &polynomials.v_read_write.rs2,
-                &polynomials.v_read_write.rd,
                 &polynomials.v_read_write.imm,
-                &polynomials.t_read,
             ],
             &opening_point,
             &combined_openings,
@@ -780,12 +780,12 @@ where
             &combined_openings,
             &[
                 &commitment.a_read_write,
+                &commitment.t_read,
                 &commitment.v_opcode,
+                &commitment.v_rd,
                 &commitment.v_rs1,
                 &commitment.v_rs2,
-                &commitment.v_rd,
                 &commitment.v_imm,
-                &commitment.t_read,
             ],
             transcript,
         )

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -758,7 +758,7 @@ where
             &commitment.read_write_generators,
             opening_point,
             &combined_openings,
-            &commitment.read_write_commitments,
+            &commitment.read_write_commitments.iter().collect::<Vec<_>>(),
             transcript,
         )
     }

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -415,10 +415,16 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> BytecodePolynomials<F, G> {
     /// Computes the maximum number of group generators needed to commit to bytecode
     /// polynomials using Hyrax, given the maximum bytecode size and maximum trace length.
     pub fn num_generators(max_bytecode_size: usize, max_trace_length: usize) -> usize {
+        // Account for no-op appended to end of bytecode
+        let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two();
+        let max_trace_length = max_trace_length.next_power_of_two();
+
         // a_read_write, t_read, v_read_write (opcode, rs1, rs2, rd, imm)
-        let num_read_write_generators = matrix_dimensions(max_trace_length, NUM_R1CS_POLYS).1;
+        let num_read_write_generators =
+            matrix_dimensions(max_trace_length.log_2(), NUM_R1CS_POLYS).1;
         // t_final, v_init_final (opcode, rs1, rs2, rd, imm)
-        let num_init_final_generators = matrix_dimensions((max_bytecode_size * 6).log_2(), 1).1;
+        let num_init_final_generators =
+            matrix_dimensions((max_bytecode_size * 6).next_power_of_two().log_2(), 1).1;
         std::cmp::max(num_read_write_generators, num_init_final_generators)
     }
 }
@@ -472,7 +478,7 @@ where
             HyraxGenerators::new(self.a_read_write.get_num_vars(), pedersen_generators);
         let read_write_commitments = [
             &self.a_read_write,
-            &self.t_read,
+            &self.t_read, // t_read isn't used in r1cs, but it's cleaner to commit to it as a rectangular matrix alongside everything else
             &self.v_read_write.opcode,
             &self.v_read_write.rd,
             &self.v_read_write.rs1,
@@ -907,13 +913,18 @@ mod tests {
             ELFRow::new(to_ram_address(3), 16u64, 16u64, 16u64, 16u64, 16u64),
             ELFRow::new(to_ram_address(2), 8u64, 8u64, 8u64, 8u64, 8u64),
         ];
+        let num_generators = BytecodePolynomials::<Fr, EdwardsProjective>::num_generators(
+            program.len(),
+            trace.len(),
+        );
+
         let polys: BytecodePolynomials<Fr, EdwardsProjective> =
             BytecodePolynomials::new(program, trace);
 
         let mut transcript = Transcript::new(b"test_transcript");
 
         let batched_polys = polys.batch();
-        let generators = PedersenGenerators::new(10, b"test");
+        let generators = PedersenGenerators::new(num_generators, b"test");
         let commitments = polys.commit(&batched_polys, &generators);
         let proof = BytecodeProof::prove_memory_checking(
             &NoPreprocessing,
@@ -947,10 +958,14 @@ mod tests {
             ELFRow::new(to_ram_address(4), 32u64, 32u64, 32u64, 32u64, 32u64),
         ];
 
+        let num_generators = BytecodePolynomials::<Fr, EdwardsProjective>::num_generators(
+            program.len(),
+            trace.len(),
+        );
         let polys: BytecodePolynomials<Fr, EdwardsProjective> =
             BytecodePolynomials::new(program, trace);
         let batch = polys.batch();
-        let generators = PedersenGenerators::new(8, b"test");
+        let generators = PedersenGenerators::new(num_generators, b"test");
         let commitments = polys.commit(&batch, &generators);
 
         let mut transcript = Transcript::new(b"test_transcript");

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -28,7 +28,7 @@ use crate::{
         unipoly::{CompressedUniPoly, UniPoly},
     },
     subprotocols::{
-        batched_commitment::{BatchedPolynomialCommitment, BatchedPolynomialOpeningProof},
+        concatenated_commitment::{ConcatenatedPolynomialCommitment, ConcatenatedPolynomialOpeningProof},
         grand_product::{BatchedGrandProductCircuit, GrandProductCircuit},
         sumcheck::SumcheckInstanceProof,
     },
@@ -89,11 +89,11 @@ pub struct BatchedInstructionPolynomials<F: PrimeField> {
 /// Commitments to BatchedInstructionPolynomials.
 pub struct InstructionCommitment<G: CurveGroup> {
     /// Commitment to dim_i and read_cts_i polynomials.
-    pub dim_read_commitment: BatchedPolynomialCommitment<G>,
+    pub dim_read_commitment: ConcatenatedPolynomialCommitment<G>,
     /// Commitment to final_cts_i polynomials.
-    pub final_commitment: BatchedPolynomialCommitment<G>,
+    pub final_commitment: ConcatenatedPolynomialCommitment<G>,
     /// Commitment to E_i and flag polynomials.
-    pub E_flag_commitment: BatchedPolynomialCommitment<G>,
+    pub E_flag_commitment: ConcatenatedPolynomialCommitment<G>,
 }
 
 /// Contains generators used to commit to InstructionPolynomials.
@@ -189,7 +189,7 @@ where
         ]
         .concat();
 
-        BatchedPolynomialOpeningProof::prove(
+        ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_E_flag,
             &commitment.E_flag_commitment,
             opening_point,
@@ -239,8 +239,8 @@ where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
 {
-    dim_read_opening_proof: BatchedPolynomialOpeningProof<G>,
-    E_flag_opening_proof: BatchedPolynomialOpeningProof<G>,
+    dim_read_opening_proof: ConcatenatedPolynomialOpeningProof<G>,
+    E_flag_opening_proof: ConcatenatedPolynomialOpeningProof<G>,
 }
 
 impl<F, G> StructuredOpeningProof<F, G, InstructionPolynomials<F, G>>
@@ -299,7 +299,7 @@ where
         ]
         .concat();
 
-        let dim_read_opening_proof = BatchedPolynomialOpeningProof::prove(
+        let dim_read_opening_proof = ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_dim_read,
             &commitment.dim_read_commitment,
             &opening_point,
@@ -313,7 +313,7 @@ where
         ]
         .concat();
 
-        let E_flag_opening_proof = BatchedPolynomialOpeningProof::prove(
+        let E_flag_opening_proof = ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_E_flag,
             &commitment.E_flag_commitment,
             &opening_point,
@@ -405,7 +405,7 @@ where
         openings: &Self,
         transcript: &mut Transcript,
     ) -> Self::Proof {
-        BatchedPolynomialOpeningProof::prove(
+        ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_final,
             &commitment.final_commitment,
             &opening_point,
@@ -797,7 +797,7 @@ pub struct PrimarySumcheck<F: PrimeField, G: CurveGroup<ScalarField = F>> {
     num_rounds: usize,
     claimed_evaluation: F,
     openings: PrimarySumcheckOpenings<F>,
-    opening_proof: BatchedPolynomialOpeningProof<G>,
+    opening_proof: ConcatenatedPolynomialOpeningProof<G>,
 }
 
 #[derive(Clone)]

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -11,7 +11,7 @@ use tracing::trace_span;
 
 use crate::jolt::instruction::SubtableIndices;
 use crate::lasso::memory_checking::MultisetHashes;
-use crate::poly::hyrax::{matrix_dimensions, HyraxGenerators};
+use crate::poly::hyrax::{square_matrix_dimensions, HyraxGenerators};
 use crate::poly::pedersen::PedersenGenerators;
 use crate::utils::{mul_0_1_optimized, split_poly_flagged};
 use crate::{
@@ -1510,7 +1510,7 @@ where
             (max_trace_length * (preprocessing.num_memories + Self::NUM_INSTRUCTIONS)).log_2();
 
         let max_num_vars = max([dim_read_num_vars, final_num_vars, E_flag_num_vars]).unwrap();
-        matrix_dimensions(max_num_vars).1.pow2()
+        square_matrix_dimensions(max_num_vars).1
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -1485,13 +1485,15 @@ where
         preprocessing: &InstructionLookupsPreprocessing<F>,
         max_trace_length: usize,
     ) -> usize {
-        let dim_read_num_vars = (max_trace_length * (C + preprocessing.num_memories)).log_2();
-        let final_num_vars = (M * preprocessing.num_memories).log_2();
-        let E_flag_num_vars =
-            (max_trace_length * (preprocessing.num_memories + Self::NUM_INSTRUCTIONS)).log_2();
-
-        let max_num_vars = max([dim_read_num_vars, final_num_vars, E_flag_num_vars]).unwrap();
-        matrix_dimensions(max_num_vars, 1).1
+        let max_trace_length = max_trace_length.next_power_of_two();
+        let num_read_write_generators =
+            matrix_dimensions(max_trace_length.log_2(), NUM_R1CS_POLYS).1;
+        let num_init_final_generators = matrix_dimensions(
+            (M * preprocessing.num_memories).next_power_of_two().log_2(),
+            1,
+        )
+        .1;
+        std::cmp::max(num_read_write_generators, num_init_final_generators)
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -274,6 +274,7 @@ where
             &NoPreprocessing,
             &polys,
             &batched_polys,
+            &commitment,
             transcript,
         );
         (proof, polys, commitment)
@@ -306,6 +307,7 @@ where
             &NoPreprocessing,
             &memory,
             &batched_polys,
+            &commitment,
             transcript,
         );
 

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -228,7 +228,6 @@ where
             .r1cs
             .verify()
             .map_err(|e| ProofVerifyError::SpartanError(e.to_string()))?;
-
         Ok(())
     }
 
@@ -274,7 +273,6 @@ where
             &NoPreprocessing,
             &polys,
             &batched_polys,
-            &commitment,
             transcript,
         );
         (proof, polys, commitment)
@@ -307,7 +305,6 @@ where
             &NoPreprocessing,
             &memory,
             &batched_polys,
-            &commitment,
             transcript,
         );
 

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -313,7 +313,6 @@ where
             read_timestamps,
             &memory,
             &batched_polys,
-            &commitment,
             &generators,
             transcript,
         );

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -267,7 +267,7 @@ where
     ) {
         let polys: BytecodePolynomials<F, G> = BytecodePolynomials::new(bytecode_rows, trace);
         let batched_polys = polys.batch();
-        let commitment = BytecodePolynomials::commit(&batched_polys, &generators);
+        let commitment = BytecodePolynomials::commit(&polys, &batched_polys, &generators);
 
         let proof = BytecodeProof::prove_memory_checking(
             &NoPreprocessing,
@@ -299,7 +299,8 @@ where
     ) {
         let (memory, read_timestamps) = ReadWriteMemory::new(bytecode, memory_trace, transcript);
         let batched_polys = memory.batch();
-        let commitment: MemoryCommitment<G> = ReadWriteMemory::commit(&batched_polys, &generators);
+        let commitment: MemoryCommitment<G> =
+            ReadWriteMemory::commit(&memory, &batched_polys, &generators);
 
         let memory_checking_proof = ReadWriteMemoryProof::prove_memory_checking(
             &NoPreprocessing,

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -506,7 +506,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> ReadWriteMemory<F, G> {
 
 pub struct BatchedMemoryPolynomials<F: PrimeField> {
     /// Contains t_read and t_write
-    batched_t_read_write: DensePolynomial<F>,
+    pub(crate) batched_t_read_write: DensePolynomial<F>,
     /// Contains:
     /// v_init, v_final, t_final
     batched_init_final: DensePolynomial<F>,

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -612,6 +612,7 @@ where
     #[tracing::instrument(skip_all, name = "MemoryReadWriteOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedMemoryPolynomials<F>,
+        commitment: &MemoryCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
@@ -627,6 +628,7 @@ where
 
         BatchedPolynomialOpeningProof::prove(
             &polynomials.batched_read_write,
+            &commitment.read_write_commitments,
             &opening_point,
             &combined_openings,
             transcript,
@@ -702,12 +704,14 @@ where
     #[tracing::instrument(skip_all, name = "MemoryInitFinalOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedMemoryPolynomials<F>,
+        commitment: &MemoryCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
     ) -> Self::Proof {
         BatchedPolynomialOpeningProof::prove(
             &polynomials.batched_init_final,
+            &commitment.init_final_commitments,
             &opening_point,
             &vec![openings.v_init, openings.v_final, openings.t_final],
             transcript,
@@ -952,6 +956,7 @@ mod tests {
             &NoPreprocessing,
             &rw_memory,
             &batched_polys,
+            &commitments,
             &mut transcript,
         );
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -17,7 +17,7 @@ use crate::{
     poly::{
         dense_mlpoly::DensePolynomial,
         eq_poly::EqPolynomial,
-        hyrax::square_matrix_dimensions,
+        hyrax::matrix_dimensions,
         identity_poly::IdentityPolynomial,
         pedersen::PedersenGenerators,
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
@@ -489,7 +489,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> ReadWriteMemory<F, G> {
         // v_init, v_final, t_final
         let init_final_num_vars = (max_memory_address * 3).log_2();
         let max_num_vars = std::cmp::max(read_write_num_vars, init_final_num_vars);
-        square_matrix_dimensions(max_num_vars).1
+        matrix_dimensions(max_num_vars, 1).1
     }
 }
 
@@ -612,7 +612,6 @@ where
     #[tracing::instrument(skip_all, name = "MemoryReadWriteOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedMemoryPolynomials<F>,
-        commitment: &MemoryCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
@@ -628,7 +627,6 @@ where
 
         ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_read_write,
-            &commitment.read_write_commitments,
             &opening_point,
             &combined_openings,
             transcript,
@@ -704,14 +702,12 @@ where
     #[tracing::instrument(skip_all, name = "MemoryInitFinalOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedMemoryPolynomials<F>,
-        commitment: &MemoryCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
     ) -> Self::Proof {
         ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_init_final,
-            &commitment.init_final_commitments,
             &opening_point,
             &vec![openings.v_init, openings.v_final, openings.t_final],
             transcript,
@@ -956,7 +952,6 @@ mod tests {
             &NoPreprocessing,
             &rw_memory,
             &batched_polys,
-            &commitments,
             &mut transcript,
         );
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -22,8 +22,8 @@ use crate::{
         pedersen::PedersenGenerators,
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
     },
-    subprotocols::batched_commitment::{
-        BatchedPolynomialCommitment, BatchedPolynomialOpeningProof,
+    subprotocols::concatenated_commitment::{
+        ConcatenatedPolynomialCommitment, ConcatenatedPolynomialOpeningProof,
     },
     utils::{errors::ProofVerifyError, math::Math, mul_0_optimized},
 };
@@ -505,11 +505,11 @@ pub struct BatchedMemoryPolynomials<F: PrimeField> {
 pub struct MemoryCommitment<G: CurveGroup> {
     /// Commitments for:
     /// a_read_write, v_read, v_write, t_read, t_write
-    pub read_write_commitments: BatchedPolynomialCommitment<G>,
+    pub read_write_commitments: ConcatenatedPolynomialCommitment<G>,
 
     /// Commitments for:
     /// v_init, v_final, t_final
-    pub init_final_commitments: BatchedPolynomialCommitment<G>,
+    pub init_final_commitments: ConcatenatedPolynomialCommitment<G>,
 }
 
 impl<F, G> BatchablePolynomials<G> for ReadWriteMemory<F, G>
@@ -626,7 +626,7 @@ where
             .chain(openings.t_write_opening.into_iter())
             .collect();
 
-        BatchedPolynomialOpeningProof::prove(
+        ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_read_write,
             &commitment.read_write_commitments,
             &opening_point,
@@ -709,7 +709,7 @@ where
         openings: &Self,
         transcript: &mut Transcript,
     ) -> Self::Proof {
-        BatchedPolynomialOpeningProof::prove(
+        ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_init_final,
             &commitment.init_final_commitments,
             &opening_point,

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -17,7 +17,7 @@ use crate::{
     poly::{
         dense_mlpoly::DensePolynomial,
         eq_poly::EqPolynomial,
-        hyrax::matrix_dimensions,
+        hyrax::square_matrix_dimensions,
         identity_poly::IdentityPolynomial,
         pedersen::PedersenGenerators,
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
@@ -489,7 +489,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> ReadWriteMemory<F, G> {
         // v_init, v_final, t_final
         let init_final_num_vars = (max_memory_address * 3).log_2();
         let max_num_vars = std::cmp::max(read_write_num_vars, init_final_num_vars);
-        matrix_dimensions(max_num_vars).1.pow2()
+        square_matrix_dimensions(max_num_vars).1
     }
 }
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -683,7 +683,10 @@ where
             &commitment.read_write_generators,
             opening_point,
             &a_v_openings,
-            &commitment.a_v_read_write_commitments,
+            &commitment
+                .a_v_read_write_commitments
+                .iter()
+                .collect::<Vec<_>>(),
             transcript,
         )?;
 

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -857,6 +857,7 @@ where
     /// Computes the maximum number of group generators needed to commit to timestamp
     /// range-check polynomials using Hyrax, given the maximum trace length.
     pub fn num_generators(max_trace_length: usize) -> usize {
+        let max_trace_length = max_trace_length.next_power_of_two();
         let batch_num_vars = (max_trace_length * MEMORY_OPS_PER_INSTRUCTION * 4).log_2();
         matrix_dimensions(batch_num_vars, 1).1
     }

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -23,7 +23,7 @@ use crate::{
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
     },
     subprotocols::{
-        batched_commitment::{BatchedPolynomialCommitment, BatchedPolynomialOpeningProof},
+        concatenated_commitment::{ConcatenatedPolynomialCommitment, ConcatenatedPolynomialOpeningProof},
         grand_product::{
             BatchedGrandProductArgument, BatchedGrandProductCircuit, GrandProductCircuit,
         },
@@ -169,7 +169,7 @@ where
     }
 }
 
-pub type RangeCheckCommitment<G> = BatchedPolynomialCommitment<G>;
+pub type RangeCheckCommitment<G> = ConcatenatedPolynomialCommitment<G>;
 pub type BatchedRangeCheckPolynomials<F> = DensePolynomial<F>;
 
 impl<F, G> BatchablePolynomials<G> for RangeCheckPolynomials<F, G>
@@ -217,8 +217,8 @@ pub struct RangeCheckOpeningProof<G>
 where
     G: CurveGroup,
 {
-    range_check_opening_proof: BatchedPolynomialOpeningProof<G>,
-    memory_poly_opening_proof: Option<BatchedPolynomialOpeningProof<G>>,
+    range_check_opening_proof: ConcatenatedPolynomialOpeningProof<G>,
+    memory_poly_opening_proof: Option<ConcatenatedPolynomialOpeningProof<G>>,
 }
 
 impl<F, G> StructuredOpeningProof<F, G, RangeCheckPolynomials<F, G>> for RangeCheckOpenings<F, G>
@@ -248,7 +248,7 @@ where
             .chain(openings.final_cts_read_timestamp.into_iter())
             .chain(openings.final_cts_global_minus_read.into_iter())
             .collect();
-        let range_check_opening_proof = BatchedPolynomialOpeningProof::prove(
+        let range_check_opening_proof = ConcatenatedPolynomialOpeningProof::prove(
             &polynomials,
             &commitment,
             opening_point,

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -17,7 +17,7 @@ use crate::{
     poly::{
         dense_mlpoly::DensePolynomial,
         eq_poly::EqPolynomial,
-        hyrax::square_matrix_dimensions,
+        hyrax::matrix_dimensions,
         identity_poly::IdentityPolynomial,
         pedersen::PedersenGenerators,
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
@@ -236,7 +236,6 @@ where
     #[tracing::instrument(skip_all, name = "RangeCheckReadWriteOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedRangeCheckPolynomials<F>,
-        commitment: &RangeCheckCommitment<G>,
         opening_point: &Vec<F>,
         openings: &RangeCheckOpenings<F, G>,
         transcript: &mut Transcript,
@@ -250,7 +249,6 @@ where
             .collect();
         let range_check_opening_proof = ConcatenatedPolynomialOpeningProof::prove(
             &polynomials,
-            &commitment,
             opening_point,
             &range_check_openings,
             transcript,
@@ -302,7 +300,6 @@ where
         _: &NoPreprocessing,
         _polynomials: &RangeCheckPolynomials<F, G>,
         _batched_polys: &BatchedRangeCheckPolynomials<F>,
-        _commitment: &RangeCheckCommitment<G>,
         _transcript: &mut Transcript,
     ) -> MemoryCheckingProof<
         G,
@@ -669,14 +666,12 @@ where
 
         let mut opening_proof = RangeCheckOpenings::prove_openings(
             &batched_range_check_polys,
-            &range_check_commitment,
             &r_grand_product,
             &openings,
             transcript,
         );
         opening_proof.memory_poly_opening_proof = Some(MemoryReadWriteOpenings::prove_openings(
             batched_memory_polynomials,
-            memory_commitment,
             &r_grand_product,
             &openings.memory_poly_openings,
             transcript,
@@ -853,7 +848,7 @@ where
     /// range-check polynomials using Hyrax, given the maximum trace length.
     pub fn num_generators(max_trace_length: usize) -> usize {
         let batch_num_vars = (max_trace_length * MEMORY_OPS_PER_INSTRUCTION * 4).log_2();
-        square_matrix_dimensions(batch_num_vars).1
+        matrix_dimensions(batch_num_vars, 1).1
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -236,6 +236,7 @@ where
     #[tracing::instrument(skip_all, name = "RangeCheckReadWriteOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedRangeCheckPolynomials<F>,
+        commitment: &RangeCheckCommitment<G>,
         opening_point: &Vec<F>,
         openings: &RangeCheckOpenings<F, G>,
         transcript: &mut Transcript,
@@ -249,6 +250,7 @@ where
             .collect();
         let range_check_opening_proof = BatchedPolynomialOpeningProof::prove(
             &polynomials,
+            &commitment,
             opening_point,
             &range_check_openings,
             transcript,
@@ -300,6 +302,7 @@ where
         _: &NoPreprocessing,
         _polynomials: &RangeCheckPolynomials<F, G>,
         _batched_polys: &BatchedRangeCheckPolynomials<F>,
+        _commitment: &RangeCheckCommitment<G>,
         _transcript: &mut Transcript,
     ) -> MemoryCheckingProof<
         G,
@@ -666,12 +669,14 @@ where
 
         let mut opening_proof = RangeCheckOpenings::prove_openings(
             &batched_range_check_polys,
+            &range_check_commitment,
             &r_grand_product,
             &openings,
             transcript,
         );
         opening_proof.memory_poly_opening_proof = Some(MemoryReadWriteOpenings::prove_openings(
             batched_memory_polynomials,
+            memory_commitment,
             &r_grand_product,
             &openings.memory_poly_openings,
             transcript,

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -17,7 +17,7 @@ use crate::{
     poly::{
         dense_mlpoly::DensePolynomial,
         eq_poly::EqPolynomial,
-        hyrax::matrix_dimensions,
+        hyrax::square_matrix_dimensions,
         identity_poly::IdentityPolynomial,
         pedersen::PedersenGenerators,
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
@@ -848,7 +848,7 @@ where
     /// range-check polynomials using Hyrax, given the maximum trace length.
     pub fn num_generators(max_trace_length: usize) -> usize {
         let batch_num_vars = (max_trace_length * MEMORY_OPS_PER_INSTRUCTION * 4).log_2();
-        matrix_dimensions(batch_num_vars).1.pow2()
+        square_matrix_dimensions(batch_num_vars).1
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -16,6 +16,7 @@ use ark_ff::PrimeField;
 use itertools::interleave;
 use merlin::Transcript;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use spartan2::traits::commitment;
 use std::iter::zip;
 use std::marker::PhantomData;
 
@@ -103,6 +104,7 @@ where
         preprocessing: &T,
         polynomials: &Polynomials,
         batched_polys: &Polynomials::BatchedPolynomials,
+        commitment: &Polynomials::Commitment,
         transcript: &mut Transcript,
     ) -> MemoryCheckingProof<G, Polynomials, Self::ReadWriteOpenings, Self::InitFinalOpenings> {
         // TODO(JOLT-62): Make sure Polynomials::Commitment have been posted to transcript.
@@ -119,6 +121,7 @@ where
         let read_write_openings = Self::ReadWriteOpenings::open(polynomials, &r_read_write);
         let read_write_opening_proof = Self::ReadWriteOpenings::prove_openings(
             batched_polys,
+            commitment,
             &r_read_write,
             &read_write_openings,
             transcript,
@@ -126,6 +129,7 @@ where
         let init_final_openings = Self::InitFinalOpenings::open(polynomials, &r_init_final);
         let init_final_opening_proof = Self::InitFinalOpenings::prove_openings(
             batched_polys,
+            commitment,
             &r_init_final,
             &init_final_openings,
             transcript,

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -16,7 +16,6 @@ use ark_ff::PrimeField;
 use itertools::interleave;
 use merlin::Transcript;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use spartan2::traits::commitment;
 use std::iter::zip;
 use std::marker::PhantomData;
 

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -118,6 +118,7 @@ where
 
         let read_write_openings = Self::ReadWriteOpenings::open(polynomials, &r_read_write);
         let read_write_opening_proof = Self::ReadWriteOpenings::prove_openings(
+            polynomials,
             batched_polys,
             &r_read_write,
             &read_write_openings,
@@ -125,6 +126,7 @@ where
         );
         let init_final_openings = Self::InitFinalOpenings::open(polynomials, &r_init_final);
         let init_final_opening_proof = Self::InitFinalOpenings::prove_openings(
+            polynomials,
             batched_polys,
             &r_init_final,
             &init_final_openings,
@@ -502,6 +504,7 @@ mod tests {
                 unimplemented!()
             }
             fn prove_openings(
+                _: &NormalMems,
                 _: &FakeType,
                 _: &Vec<Fr>,
                 _: &Self,
@@ -528,6 +531,7 @@ mod tests {
                 unimplemented!()
             }
             fn commit(
+                &self,
                 _batched_polys: &Self::BatchedPolynomials,
                 _generators: &PedersenGenerators<EdwardsProjective>,
             ) -> Self::Commitment {
@@ -704,6 +708,7 @@ mod tests {
                 unimplemented!()
             }
             fn prove_openings(
+                _: &Polys,
                 _: &FakeType,
                 _: &Vec<Fr>,
                 _: &Self,
@@ -730,6 +735,7 @@ mod tests {
                 unimplemented!()
             }
             fn commit(
+                &self,
                 _batched_polys: &Self::BatchedPolynomials,
                 _generators: &PedersenGenerators<EdwardsProjective>,
             ) -> Self::Commitment {
@@ -952,6 +958,7 @@ mod tests {
                 unimplemented!()
             }
             fn prove_openings(
+                _: &FlagPolys,
                 _: &FakeType,
                 _: &Vec<Fr>,
                 _: &Self,
@@ -978,6 +985,7 @@ mod tests {
                 unimplemented!()
             }
             fn commit(
+                &self,
                 _batched_polys: &Self::BatchedPolynomials,
                 _generators: &PedersenGenerators<EdwardsProjective>,
             ) -> Self::Commitment {

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -103,7 +103,6 @@ where
         preprocessing: &T,
         polynomials: &Polynomials,
         batched_polys: &Polynomials::BatchedPolynomials,
-        commitment: &Polynomials::Commitment,
         transcript: &mut Transcript,
     ) -> MemoryCheckingProof<G, Polynomials, Self::ReadWriteOpenings, Self::InitFinalOpenings> {
         // TODO(JOLT-62): Make sure Polynomials::Commitment have been posted to transcript.
@@ -120,7 +119,6 @@ where
         let read_write_openings = Self::ReadWriteOpenings::open(polynomials, &r_read_write);
         let read_write_opening_proof = Self::ReadWriteOpenings::prove_openings(
             batched_polys,
-            commitment,
             &r_read_write,
             &read_write_openings,
             transcript,
@@ -128,7 +126,6 @@ where
         let init_final_openings = Self::InitFinalOpenings::open(polynomials, &r_init_final);
         let init_final_opening_proof = Self::InitFinalOpenings::prove_openings(
             batched_polys,
-            commitment,
             &r_init_final,
             &init_final_openings,
             transcript,

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -108,12 +108,14 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> StructuredOpeningProof<F, G,
     #[tracing::instrument(skip_all, name = "PrimarySumcheckOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedSurgePolynomials<F>,
+        commitment: &SurgeCommitment<G>,
         opening_point: &Vec<F>,
         E_poly_openings: &Vec<F>,
         transcript: &mut Transcript,
     ) -> Self::Proof {
         BatchedPolynomialOpeningProof::prove(
             &polynomials.batched_E,
+            &commitment.E_commitment,
             opening_point,
             E_poly_openings,
             transcript,
@@ -170,6 +172,7 @@ where
     #[tracing::instrument(skip_all, name = "SurgeReadWriteOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedSurgePolynomials<F>,
+        commitment: &SurgeCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
@@ -184,12 +187,14 @@ where
 
         let dim_read_opening_proof = BatchedPolynomialOpeningProof::prove(
             &polynomials.batched_dim_read,
+            &commitment.dim_read_commitment,
             &opening_point,
             &dim_read_openings,
             transcript,
         );
         let E_poly_opening_proof = BatchedPolynomialOpeningProof::prove(
             &polynomials.batched_E,
+            &commitment.E_commitment,
             &opening_point,
             &openings.E_poly_openings,
             transcript,
@@ -268,12 +273,14 @@ where
     #[tracing::instrument(skip_all, name = "SurgeFinalOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedSurgePolynomials<F>,
+        commitment: &SurgeCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
     ) -> Self::Proof {
         BatchedPolynomialOpeningProof::prove(
             &polynomials.batched_final,
+            &commitment.final_commitment,
             &opening_point,
             &openings.final_openings,
             transcript,
@@ -632,6 +639,7 @@ where
                                                                                    // Create a single opening proof for the E polynomials
         let sumcheck_opening_proof = PrimarySumcheckOpenings::prove_openings(
             &batched_polys,
+            &commitment,
             &r_z,
             &sumcheck_openings,
             transcript,
@@ -649,6 +657,7 @@ where
             &preprocessing,
             &polynomials,
             &batched_polys,
+            &commitment,
             transcript,
         );
 

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -16,7 +16,7 @@ use crate::{
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
     },
     subprotocols::{
-        batched_commitment::{BatchedPolynomialCommitment, BatchedPolynomialOpeningProof},
+        concatenated_commitment::{ConcatenatedPolynomialCommitment, ConcatenatedPolynomialOpeningProof},
         sumcheck::SumcheckInstanceProof,
     },
     utils::{errors::ProofVerifyError, math::Math, mul_0_1_optimized, transcript::ProofTranscript},
@@ -37,9 +37,9 @@ pub struct BatchedSurgePolynomials<F: PrimeField> {
 }
 
 pub struct SurgeCommitment<G: CurveGroup> {
-    pub dim_read_commitment: BatchedPolynomialCommitment<G>,
-    pub final_commitment: BatchedPolynomialCommitment<G>,
-    pub E_commitment: BatchedPolynomialCommitment<G>,
+    pub dim_read_commitment: ConcatenatedPolynomialCommitment<G>,
+    pub final_commitment: ConcatenatedPolynomialCommitment<G>,
+    pub E_commitment: ConcatenatedPolynomialCommitment<G>,
 }
 
 impl<F, G> BatchablePolynomials<G> for SurgePolys<F, G>
@@ -113,7 +113,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> StructuredOpeningProof<F, G,
         E_poly_openings: &Vec<F>,
         transcript: &mut Transcript,
     ) -> Self::Proof {
-        BatchedPolynomialOpeningProof::prove(
+        ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_E,
             &commitment.E_commitment,
             opening_point,
@@ -147,8 +147,8 @@ where
     F: PrimeField,
     G: CurveGroup<ScalarField = F>,
 {
-    dim_read_opening_proof: BatchedPolynomialOpeningProof<G>,
-    E_poly_opening_proof: BatchedPolynomialOpeningProof<G>,
+    dim_read_opening_proof: ConcatenatedPolynomialOpeningProof<G>,
+    E_poly_opening_proof: ConcatenatedPolynomialOpeningProof<G>,
 }
 
 impl<F, G> StructuredOpeningProof<F, G, SurgePolys<F, G>> for SurgeReadWriteOpenings<F>
@@ -185,14 +185,14 @@ where
         .to_vec();
         dim_read_openings.resize(dim_read_openings.len().next_power_of_two(), F::zero());
 
-        let dim_read_opening_proof = BatchedPolynomialOpeningProof::prove(
+        let dim_read_opening_proof = ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_dim_read,
             &commitment.dim_read_commitment,
             &opening_point,
             &dim_read_openings,
             transcript,
         );
-        let E_poly_opening_proof = BatchedPolynomialOpeningProof::prove(
+        let E_poly_opening_proof = ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_E,
             &commitment.E_commitment,
             &opening_point,
@@ -278,7 +278,7 @@ where
         openings: &Self,
         transcript: &mut Transcript,
     ) -> Self::Proof {
-        BatchedPolynomialOpeningProof::prove(
+        ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_final,
             &commitment.final_commitment,
             &opening_point,
@@ -488,7 +488,7 @@ pub struct SurgePrimarySumcheck<F: PrimeField, G: CurveGroup<ScalarField = F>> {
     num_rounds: usize,
     claimed_evaluation: F,
     openings: PrimarySumcheckOpenings<F>,
-    opening_proof: BatchedPolynomialOpeningProof<G>,
+    opening_proof: ConcatenatedPolynomialOpeningProof<G>,
 }
 
 pub struct SurgePreprocessing<F, Instruction, const C: usize, const M: usize>

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -10,7 +10,7 @@ use crate::{
     poly::{
         dense_mlpoly::DensePolynomial,
         eq_poly::EqPolynomial,
-        hyrax::square_matrix_dimensions,
+        hyrax::matrix_dimensions,
         identity_poly::IdentityPolynomial,
         pedersen::PedersenGenerators,
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
@@ -108,14 +108,12 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> StructuredOpeningProof<F, G,
     #[tracing::instrument(skip_all, name = "PrimarySumcheckOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedSurgePolynomials<F>,
-        commitment: &SurgeCommitment<G>,
         opening_point: &Vec<F>,
         E_poly_openings: &Vec<F>,
         transcript: &mut Transcript,
     ) -> Self::Proof {
         ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_E,
-            &commitment.E_commitment,
             opening_point,
             E_poly_openings,
             transcript,
@@ -172,7 +170,6 @@ where
     #[tracing::instrument(skip_all, name = "SurgeReadWriteOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedSurgePolynomials<F>,
-        commitment: &SurgeCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
@@ -187,14 +184,12 @@ where
 
         let dim_read_opening_proof = ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_dim_read,
-            &commitment.dim_read_commitment,
             &opening_point,
             &dim_read_openings,
             transcript,
         );
         let E_poly_opening_proof = ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_E,
-            &commitment.E_commitment,
             &opening_point,
             &openings.E_poly_openings,
             transcript,
@@ -273,14 +268,12 @@ where
     #[tracing::instrument(skip_all, name = "SurgeFinalOpenings::prove_openings")]
     fn prove_openings(
         polynomials: &BatchedSurgePolynomials<F>,
-        commitment: &SurgeCommitment<G>,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,
     ) -> Self::Proof {
         ConcatenatedPolynomialOpeningProof::prove(
             &polynomials.batched_final,
-            &commitment.final_commitment,
             &opening_point,
             &openings.final_openings,
             transcript,
@@ -577,7 +570,7 @@ where
 
         let max_num_vars =
             std::cmp::max(std::cmp::max(dim_read_num_vars, final_num_vars), E_num_vars);
-        square_matrix_dimensions(max_num_vars).1
+        matrix_dimensions(max_num_vars, 1).1
     }
 
     #[tracing::instrument(skip_all, name = "Surge::prove")]
@@ -639,7 +632,6 @@ where
                                                                                    // Create a single opening proof for the E polynomials
         let sumcheck_opening_proof = PrimarySumcheckOpenings::prove_openings(
             &batched_polys,
-            &commitment,
             &r_z,
             &sumcheck_openings,
             transcript,
@@ -657,7 +649,6 @@ where
             &preprocessing,
             &polynomials,
             &batched_polys,
-            &commitment,
             transcript,
         );
 

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -10,7 +10,7 @@ use crate::{
     poly::{
         dense_mlpoly::DensePolynomial,
         eq_poly::EqPolynomial,
-        hyrax::matrix_dimensions,
+        hyrax::square_matrix_dimensions,
         identity_poly::IdentityPolynomial,
         pedersen::PedersenGenerators,
         structured_poly::{BatchablePolynomials, StructuredOpeningProof},
@@ -570,7 +570,7 @@ where
 
         let max_num_vars =
             std::cmp::max(std::cmp::max(dim_read_num_vars, final_num_vars), E_num_vars);
-        matrix_dimensions(max_num_vars).1.pow2()
+        square_matrix_dimensions(max_num_vars).1
     }
 
     #[tracing::instrument(skip_all, name = "Surge::prove")]

--- a/jolt-core/src/msm/mod.rs
+++ b/jolt-core/src/msm/mod.rs
@@ -11,7 +11,7 @@ impl<G: CurveGroup> VariableBaseMSM for G {}
 /// Copy of ark_ec::VariableBaseMSM with minor modifications to speed up
 /// known small element sized MSMs.
 pub trait VariableBaseMSM: ScalarMul {
-    fn msm_u64(bases: &[Self::MulBase], scalars: &[Self::ScalarField]) -> Result<Self, usize> {
+    fn msm(bases: &[Self::MulBase], scalars: &[Self::ScalarField]) -> Result<Self, usize> {
         (bases.len() == scalars.len())
             .then(|| {
                 let max_num_bits = scalars

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -226,6 +226,17 @@ impl<F: PrimeField> DensePolynomial<F> {
         DensePolynomial::new(Z)
     }
 
+    pub fn hyrax_commit_rectangular<G>(
+        &self,
+        pedersen_generators: &PedersenGenerators<G>,
+    ) -> HyraxCommitment<G>
+    where
+        G: CurveGroup<ScalarField = F>,
+    {
+        let generators = HyraxGenerators::new(self.get_num_vars(), pedersen_generators);
+        HyraxCommitment::commit_rectangular_matrix(&self, &generators)
+    }
+
     pub fn combined_commit<G>(
         &self,
         pedersen_generators: &PedersenGenerators<G>,

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -234,7 +234,7 @@ impl<F: PrimeField> DensePolynomial<F> {
         G: CurveGroup<ScalarField = F>,
     {
         let generators = HyraxGenerators::new(self.get_num_vars(), pedersen_generators);
-        let joint_commitment = HyraxCommitment::commit(&self, &generators);
+        let joint_commitment = HyraxCommitment::commit_square_matrix(&self, &generators);
         BatchedPolynomialCommitment {
             generators,
             joint_commitment,
@@ -333,7 +333,7 @@ pub mod bench {
     }
 
     pub fn run_commit_bench(gens: HyraxGenerators<EdwardsProjective>, poly: DensePolynomial<Fr>) {
-        let result = black_box(HyraxCommitment::commit(&poly, &gens));
+        let result = black_box(HyraxCommitment::commit_square_matrix(&poly, &gens));
         black_box(result);
     }
 }

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -4,7 +4,7 @@ use crate::utils::{self, compute_dotproduct, compute_dotproduct_low_optimized, m
 
 use super::hyrax::{HyraxCommitment, HyraxGenerators};
 use super::pedersen::PedersenGenerators;
-use crate::subprotocols::batched_commitment::BatchedPolynomialCommitment;
+use crate::subprotocols::concatenated_commitment::ConcatenatedPolynomialCommitment;
 use crate::utils::math::Math;
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
@@ -240,13 +240,13 @@ impl<F: PrimeField> DensePolynomial<F> {
     pub fn combined_commit<G>(
         &self,
         pedersen_generators: &PedersenGenerators<G>,
-    ) -> BatchedPolynomialCommitment<G>
+    ) -> ConcatenatedPolynomialCommitment<G>
     where
         G: CurveGroup<ScalarField = F>,
     {
         let generators = HyraxGenerators::new(self.get_num_vars(), pedersen_generators);
         let joint_commitment = HyraxCommitment::commit_square_matrix(&self, &generators);
-        BatchedPolynomialCommitment {
+        ConcatenatedPolynomialCommitment {
             generators,
             joint_commitment,
         }

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -340,6 +340,8 @@ pub mod bench {
 
 #[cfg(test)]
 mod tests {
+    use crate::poly::hyrax::square_matrix_dimensions;
+
     use super::*;
     use ark_curve25519::EdwardsProjective as G1Projective;
     use ark_curve25519::Fr;
@@ -351,10 +353,11 @@ mod tests {
         Z: &[G::ScalarField],
         r: &[G::ScalarField],
     ) -> G::ScalarField {
-        let eq = EqPolynomial::<G::ScalarField>::new(r.to_vec());
-        let (L, R) = eq.compute_factored_evals();
-
         let ell = r.len();
+        let (L_size, _R_size) = square_matrix_dimensions(ell);
+        let eq = EqPolynomial::<G::ScalarField>::new(r.to_vec());
+        let (L, R) = eq.compute_factored_evals(L_size);
+
         // ensure ell is even
         assert!(ell % 2 == 0);
         // compute n = 2^\ell
@@ -496,7 +499,8 @@ mod tests {
             r.push(F::rand(&mut prng));
         }
         let chis = EqPolynomial::new(r.clone()).evals();
-        let (L, R) = EqPolynomial::new(r).compute_factored_evals();
+        let (L_size, _R_size) = square_matrix_dimensions(r.len());
+        let (L, R) = EqPolynomial::new(r).compute_factored_evals(L_size);
         let O = compute_outerproduct(&L, &R);
         assert_eq!(chis, O);
     }
@@ -516,7 +520,8 @@ mod tests {
         }
         let (L, R) = compute_factored_chis_at_r(&r);
         let eq = EqPolynomial::new(r);
-        let (L2, R2) = eq.compute_factored_evals();
+        let (L_size, _R_size) = square_matrix_dimensions(r.len());
+        let (L2, R2) = eq.compute_factored_evals(L_size);
         assert_eq!(L, L2);
         assert_eq!(R, R2);
     }

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -226,17 +226,6 @@ impl<F: PrimeField> DensePolynomial<F> {
         DensePolynomial::new(Z)
     }
 
-    pub fn hyrax_commit_rectangular<G>(
-        &self,
-        pedersen_generators: &PedersenGenerators<G>,
-    ) -> HyraxCommitment<G>
-    where
-        G: CurveGroup<ScalarField = F>,
-    {
-        let generators = HyraxGenerators::new(self.get_num_vars(), pedersen_generators);
-        HyraxCommitment::commit_rectangular_matrix(&self, &generators)
-    }
-
     pub fn combined_commit<G>(
         &self,
         pedersen_generators: &PedersenGenerators<G>,

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -521,9 +521,9 @@ mod tests {
         for _i in 0..s {
             r.push(F::rand(&mut prng));
         }
+        let (L_size, _R_size) = matrix_dimensions(r.len(), 1);
         let (L, R) = compute_factored_chis_at_r(&r);
         let eq = EqPolynomial::new(r);
-        let (L_size, _R_size) = matrix_dimensions(r.len(), 1);
         let (L2, R2) = eq.compute_factored_evals(L_size);
         assert_eq!(L, L2);
         assert_eq!(R, R2);

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -77,10 +77,9 @@ impl<F: PrimeField> EqPolynomial<F> {
         evals
     }
 
-    #[tracing::instrument(skip_all, name = "EqPolynomial.compute_factored_evals")]
-    pub fn compute_factored_evals(&self) -> (Vec<F>, Vec<F>) {
+    #[tracing::instrument(skip_all, name = "EqPolynomial::compute_factored_evals")]
+    pub fn compute_factored_evals(&self, L_size: usize) -> (Vec<F>, Vec<F>) {
         let ell = self.r.len();
-        let (L_size, _) = super::hyrax::square_matrix_dimensions(ell);
         let left_num_vars = L_size.log_2();
 
         let L = EqPolynomial::new(self.r[..left_num_vars].to_vec()).evals();

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -80,7 +80,8 @@ impl<F: PrimeField> EqPolynomial<F> {
     #[tracing::instrument(skip_all, name = "EqPolynomial.compute_factored_evals")]
     pub fn compute_factored_evals(&self) -> (Vec<F>, Vec<F>) {
         let ell = self.r.len();
-        let (left_num_vars, _right_num_vars) = super::hyrax::matrix_dimensions(ell);
+        let (L_size, _) = super::hyrax::square_matrix_dimensions(ell);
+        let left_num_vars = L_size.log_2();
 
         let L = EqPolynomial::new(self.r[..left_num_vars].to_vec()).evals();
         let R = EqPolynomial::new(self.r[left_num_vars..ell].to_vec()).evals();

--- a/jolt-core/src/poly/hyrax.rs
+++ b/jolt-core/src/poly/hyrax.rs
@@ -22,7 +22,8 @@ pub fn matrix_dimensions(num_vars: usize, matrix_aspect_ratio: usize) -> (usize,
     let mut row_size = (num_vars / 2).pow2();
     row_size = (row_size * matrix_aspect_ratio.sqrt()).next_power_of_two();
 
-    let right_num_vars = row_size.log_2();
+    let right_num_vars = std::cmp::min(row_size.log_2(), num_vars - 1);
+    row_size = right_num_vars.pow2();
     let left_num_vars = num_vars - right_num_vars;
     let col_size = left_num_vars.pow2();
 

--- a/jolt-core/src/poly/hyrax.rs
+++ b/jolt-core/src/poly/hyrax.rs
@@ -44,6 +44,7 @@ impl<G: CurveGroup> HyraxGenerators<G> {
     }
 }
 
+#[derive(Debug)]
 pub struct HyraxCommitment<G: CurveGroup> {
     row_commitments: Vec<G>,
 }
@@ -217,8 +218,8 @@ pub struct BatchedHyraxOpeningProof<G: CurveGroup> {
 impl<G: CurveGroup> BatchedHyraxOpeningProof<G> {
     #[tracing::instrument(skip_all, name = "BatchedHyraxOpeningProof::prove")]
     pub fn prove(
-        polynomials: &[DensePolynomial<G::ScalarField>],
-        commitments: &[HyraxCommitment<G>],
+        polynomials: &[&DensePolynomial<G::ScalarField>],
+        commitments: &[&HyraxCommitment<G>],
         opening_point: &[G::ScalarField],
         openings: &[G::ScalarField],
         transcript: &mut Transcript,
@@ -251,7 +252,6 @@ impl<G: CurveGroup> BatchedHyraxOpeningProof<G> {
                         .collect()
                 },
             );
-        let rlc_eval = compute_dotproduct(&rlc_coefficients, openings);
 
         let joint_proof = HyraxOpeningProof::prove(
             &DensePolynomial::new(rlc_poly),
@@ -267,7 +267,7 @@ impl<G: CurveGroup> BatchedHyraxOpeningProof<G> {
         gens: &HyraxGenerators<G>,
         opening_point: &[G::ScalarField],
         openings: &[G::ScalarField],
-        commitments: &[HyraxCommitment<G>],
+        commitments: &[&HyraxCommitment<G>],
         transcript: &mut Transcript,
     ) -> Result<(), ProofVerifyError> {
         <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());

--- a/jolt-core/src/poly/hyrax.rs
+++ b/jolt-core/src/poly/hyrax.rs
@@ -159,7 +159,7 @@ impl<const RATIO: usize, G: CurveGroup> HyraxOpeningProof<RATIO, G> {
         poly: &DensePolynomial<G::ScalarField>,
         L: &[G::ScalarField],
     ) -> Vec<G::ScalarField> {
-        let (_, R_size) = super::hyrax::matrix_dimensions(poly.get_num_vars(), RATIO);
+        let (_, R_size) = matrix_dimensions(poly.get_num_vars(), RATIO);
 
         poly.evals_ref()
             .par_chunks(R_size)
@@ -257,7 +257,7 @@ impl<const RATIO: usize, G: CurveGroup> BatchedHyraxOpeningProof<RATIO, G> {
                 commitment
                     .row_commitments
                     .iter()
-                    .map(|commitment| *commitment * coeff)
+                    .map(|row_commitment| *row_commitment * coeff)
                     .collect()
             })
             .reduce(

--- a/jolt-core/src/poly/hyrax.rs
+++ b/jolt-core/src/poly/hyrax.rs
@@ -232,7 +232,7 @@ impl<const RATIO: usize, G: CurveGroup> BatchedHyraxOpeningProof<RATIO, G> {
         gens: &HyraxGenerators<RATIO, G>,
         opening_point: &[G::ScalarField],
         openings: &[G::ScalarField],
-        commitments: &[&HyraxCommitment<RATIO, G>],
+        commitments: &[HyraxCommitment<RATIO, G>],
         transcript: &mut Transcript,
     ) -> Result<(), ProofVerifyError> {
         let (L_size, _R_size) = matrix_dimensions(opening_point.len(), RATIO);

--- a/jolt-core/src/poly/hyrax.rs
+++ b/jolt-core/src/poly/hyrax.rs
@@ -232,7 +232,7 @@ impl<const RATIO: usize, G: CurveGroup> BatchedHyraxOpeningProof<RATIO, G> {
         gens: &HyraxGenerators<RATIO, G>,
         opening_point: &[G::ScalarField],
         openings: &[G::ScalarField],
-        commitments: &[HyraxCommitment<RATIO, G>],
+        commitments: &[&HyraxCommitment<RATIO, G>],
         transcript: &mut Transcript,
     ) -> Result<(), ProofVerifyError> {
         let (L_size, _R_size) = matrix_dimensions(opening_point.len(), RATIO);

--- a/jolt-core/src/poly/pedersen.rs
+++ b/jolt-core/src/poly/pedersen.rs
@@ -77,6 +77,6 @@ impl<G: CurveGroup> PedersenCommitment<G> for G::ScalarField {
 
     fn commit_vector(inputs: &[Self], bases: &[G::Affine]) -> G {
         assert_eq!(bases.len(), inputs.len());
-        VariableBaseMSM::msm_u64(&bases, &inputs).unwrap()
+        VariableBaseMSM::msm(&bases, &inputs).unwrap()
     }
 }

--- a/jolt-core/src/poly/structured_poly.rs
+++ b/jolt-core/src/poly/structured_poly.rs
@@ -4,7 +4,7 @@ use merlin::Transcript;
 
 use super::pedersen::PedersenGenerators;
 use crate::{
-    subprotocols::batched_commitment::BatchedPolynomialOpeningProof,
+    subprotocols::concatenated_commitment::ConcatenatedPolynomialOpeningProof,
     utils::errors::ProofVerifyError,
 };
 
@@ -37,7 +37,7 @@ where
     G: CurveGroup<ScalarField = F>,
     Polynomials: BatchablePolynomials<G> + ?Sized,
 {
-    type Proof = BatchedPolynomialOpeningProof<G>;
+    type Proof = ConcatenatedPolynomialOpeningProof<G>;
 
     /// Evaluates each fo the given `polynomials` at the given `opening_point`.
     fn open(polynomials: &Polynomials, opening_point: &Vec<F>) -> Self;

--- a/jolt-core/src/poly/structured_poly.rs
+++ b/jolt-core/src/poly/structured_poly.rs
@@ -46,6 +46,7 @@ where
     /// by `openings`. The polynomials should already be committed by the prover (`commitment`).
     fn prove_openings(
         polynomials: &Polynomials::BatchedPolynomials,
+        commitment: &Polynomials::Commitment,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,

--- a/jolt-core/src/poly/structured_poly.rs
+++ b/jolt-core/src/poly/structured_poly.rs
@@ -43,10 +43,9 @@ where
     fn open(polynomials: &Polynomials, opening_point: &Vec<F>) -> Self;
 
     /// Proves that the `polynomials`, evaluated at `opening_point`, output the values given
-    /// by `openings`. The polynomials should already be committed by the prover (`commitment`).
+    /// by `openings`. The polynomials should already be committed by the prover.
     fn prove_openings(
         polynomials: &Polynomials::BatchedPolynomials,
-        commitment: &Polynomials::Commitment,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,

--- a/jolt-core/src/poly/structured_poly.rs
+++ b/jolt-core/src/poly/structured_poly.rs
@@ -22,6 +22,7 @@ pub trait BatchablePolynomials<G: CurveGroup> {
     fn batch(&self) -> Self::BatchedPolynomials;
     /// Commits to batched polynomials, typically using `DensePolynomial::combined_commit`.
     fn commit(
+        &self,
         batched_polys: &Self::BatchedPolynomials,
         generators: &PedersenGenerators<G>,
     ) -> Self::Commitment;
@@ -45,7 +46,8 @@ where
     /// Proves that the `polynomials`, evaluated at `opening_point`, output the values given
     /// by `openings`. The polynomials should already be committed by the prover.
     fn prove_openings(
-        polynomials: &Polynomials::BatchedPolynomials,
+        polynomials: &Polynomials,
+        batched_polynomials: &Polynomials::BatchedPolynomials,
         opening_point: &Vec<F>,
         openings: &Self,
         transcript: &mut Transcript,

--- a/jolt-core/src/subprotocols/batched_commitment.rs
+++ b/jolt-core/src/subprotocols/batched_commitment.rs
@@ -28,6 +28,7 @@ impl<G: CurveGroup> BatchedPolynomialOpeningProof<G> {
     #[tracing::instrument(skip_all, name = "BatchedPolynomialOpeningProof::prove")]
     pub fn prove(
         combined_poly: &DensePolynomial<G::ScalarField>,
+        commitment: &BatchedPolynomialCommitment<G>,
         opening_point: &[G::ScalarField],
         openings: &[G::ScalarField],
         transcript: &mut Transcript,
@@ -78,7 +79,12 @@ impl<G: CurveGroup> BatchedPolynomialOpeningProof<G> {
             &eval_joint,
         );
 
-        let joint_proof = HyraxOpeningProof::prove(combined_poly, &r_joint, transcript);
+        let joint_proof = HyraxOpeningProof::prove(
+            combined_poly,
+            &commitment.joint_commitment,
+            &r_joint,
+            transcript,
+        );
 
         BatchedPolynomialOpeningProof { joint_proof }
     }

--- a/jolt-core/src/subprotocols/concatenated_commitment.rs
+++ b/jolt-core/src/subprotocols/concatenated_commitment.rs
@@ -33,10 +33,7 @@ impl<G: CurveGroup> ConcatenatedPolynomialOpeningProof<G> {
         openings: &[G::ScalarField],
         transcript: &mut Transcript,
     ) -> Self {
-        <Transcript as ProofTranscript<G>>::append_protocol_name(
-            transcript,
-            ConcatenatedPolynomialOpeningProof::<G>::protocol_name(),
-        );
+        <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());
 
         let evals = {
             let mut evals: Vec<G::ScalarField> = openings.to_vec();
@@ -97,10 +94,8 @@ impl<G: CurveGroup> ConcatenatedPolynomialOpeningProof<G> {
         commitment: &ConcatenatedPolynomialCommitment<G>,
         transcript: &mut Transcript,
     ) -> Result<(), ProofVerifyError> {
-        <Transcript as ProofTranscript<G>>::append_protocol_name(
-            transcript,
-            ConcatenatedPolynomialOpeningProof::<G>::protocol_name(),
-        );
+        <Transcript as ProofTranscript<G>>::append_protocol_name(transcript, Self::protocol_name());
+        
         let mut evals = openings.to_owned();
         evals.resize(evals.len().next_power_of_two(), G::ScalarField::zero());
 

--- a/jolt-core/src/subprotocols/concatenated_commitment.rs
+++ b/jolt-core/src/subprotocols/concatenated_commitment.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 pub struct ConcatenatedPolynomialCommitment<G: CurveGroup> {
-    pub generators: HyraxGenerators<G>,
-    pub joint_commitment: HyraxCommitment<G>,
+    pub generators: HyraxGenerators<1, G>,
+    pub joint_commitment: HyraxCommitment<1, G>,
 }
 
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct ConcatenatedPolynomialOpeningProof<G: CurveGroup> {
-    joint_proof: HyraxOpeningProof<G>,
+    joint_proof: HyraxOpeningProof<1, G>,
 }
 
 impl<G: CurveGroup> ConcatenatedPolynomialOpeningProof<G> {
@@ -28,7 +28,6 @@ impl<G: CurveGroup> ConcatenatedPolynomialOpeningProof<G> {
     #[tracing::instrument(skip_all, name = "ConcatenatedPolynomialOpeningProof::prove")]
     pub fn prove(
         concatenated_poly: &DensePolynomial<G::ScalarField>,
-        commitment: &ConcatenatedPolynomialCommitment<G>,
         opening_point: &[G::ScalarField],
         openings: &[G::ScalarField],
         transcript: &mut Transcript,
@@ -78,7 +77,6 @@ impl<G: CurveGroup> ConcatenatedPolynomialOpeningProof<G> {
 
         let joint_proof = HyraxOpeningProof::prove(
             concatenated_poly,
-            &commitment.joint_commitment,
             &r_joint,
             transcript,
         );

--- a/jolt-core/src/subprotocols/mod.rs
+++ b/jolt-core/src/subprotocols/mod.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::too_many_arguments)]
 
-pub mod batched_commitment;
+pub mod concatenated_commitment;
 pub mod grand_product;
 pub mod sumcheck;


### PR DESCRIPTION
Previously, read/write polynomials were concatenated together and committed to using Hyrax. 
With this PR, those polynomials are committed to individually so they can be passed to spartan2.
As part of this change, we introduce batched Hyrax opening proofs (multiple commitments, opened at the same point) and rectangular Hyrax (i.e. the matrix representation of the committed polynomial's coefficients is not square). The latter is important for efficiency. 