### PR TITLE
Constraints/state pc loads

### DIFF
--- a/common/src/rv_trace.rs
+++ b/common/src/rv_trace.rs
@@ -327,16 +327,6 @@ impl ELFInstruction {
         flags[7] = match self.opcode {
             RV32IM::ADD 
             | RV32IM::ADDI 
-            // Store and load instructions only have one lookup operand (rs2 and the RAM word, respectively)
-            // so we add the operand to a dummy operand of 0 in the circuit to obtain the lookup query.
-            | RV32IM::SB
-            | RV32IM::SH
-            | RV32IM::SW
-            | RV32IM::LB
-            | RV32IM::LH
-            | RV32IM::LW
-            | RV32IM::LBU
-            | RV32IM::LHU
             | RV32IM::JAL 
             | RV32IM::JALR 
             | RV32IM::AUIPC => true,

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -310,7 +310,6 @@ impl R1CSBuilder {
         let PC = GET_INDEX(InputType::InputState, PC_IDX); 
 
         // Constraint 1: relation between PC and prog_a_rw
-        // TODO(arasuarun): this should be done after fixing the padding issue for prog_a_rw
         R1CSBuilder::constr_abc(instance, 
             smallvec![(GET_INDEX(InputType::ProgARW, 0), 4), (0, PC_START_ADDRESS as i64), (PC, -1)], 
             smallvec![(PC, 1)], 

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -316,6 +316,11 @@ impl R1CSBuilder {
 
         // Constraint 1: relation between PC and prog_a_rw
         // TODO(arasuarun): this should be done after fixing the padding issue for prog_a_rw
+        R1CSBuilder::constr_abc(instance, 
+            smallvec![(GET_INDEX(InputType::ProgARW, 0), 4), (0, PC_START_ADDRESS as i64), (PC, -1)], 
+            smallvec![(PC, 1)], 
+            smallvec![], 
+        ); 
 
         // Combine flag_bits and check that they equal op_flags_packed. 
         R1CSBuilder::combine_constraint(instance,

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -139,7 +139,7 @@ impl<F: PrimeField> R1CSInputs<F> {
 
   #[tracing::instrument(skip_all, name = "R1CSInputs::clone_to_stepwise")]
   pub fn clone_to_stepwise(&self) -> Vec<Vec<F>> {
-    const PREFIX_VARS_PER_STEP: usize = 5;
+    const PREFIX_VARS_PER_STEP: usize = 3;
 
     // AUX_VARS_PER_STEP has to be greater than the number of additional vars pushed by the constraint system
     const AUX_VARS_PER_STEP: usize = 20; 
@@ -154,7 +154,7 @@ impl<F: PrimeField> R1CSInputs<F> {
       };
 
       // 1 is constant, 0s in slots 1, 2 are filled by aux computation
-      step.extend([F::from(1u64), F::from(0u64), F::from(0u64), F::from(step_index as u64), program_counter]);
+      step.extend([F::from(1u64), F::from(0u64), program_counter]);
 
       let push_to_step = |data: &Vec<F>, step: &mut Vec<F>| {
         let num_vals = data.len() / self.padded_trace_len;
@@ -294,7 +294,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> R1CSProof<F, G> {
       drop(_enter);
       drop(span);
 
-      let (io_segments, aux_segments) = synthesize_state_aux_segments(&inputs, 4, jolt_shape.num_internal);
+      let (io_segments, aux_segments) = synthesize_state_aux_segments(&inputs, 2, jolt_shape.num_internal);
       let io_comms = HyraxCommitment::batch_commit(&io_segments, &generators);
       let aux_comms = HyraxCommitment::batch_commit(&aux_segments, &generators);
 


### PR DESCRIPTION
1. Removes the step counter from the state. 
2. Enforces the correct program counter value (doesn't map to a lower address space, though).
3. Enforces the correct lookup query for load sign-extension lookups 