### PR TITLE
feat: add jolt tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,16 @@ members = [
     "examples/multi-function/guest",
 ]
 
+[lib]
+path = "./src/lib.rs"
+
+[[bin]]
+name = "jolt"
+path = "./src/main.rs"
+
+[dependencies]
+jolt-sdk = { path = "./jolt-sdk" }
+
 [profile.test]
 opt-level = 3
 lto = "off"
@@ -57,9 +67,6 @@ lto = "off"
 [profile.guest]
 inherits = "release"
 debug = false
-
-[dependencies]
-jolt-sdk = { path = "./jolt-sdk" }
 
 [patch.crates-io]
 ark-ff = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ members = [
     "examples/multi-function/guest",
 ]
 
+[features]
+std = []
+
 [lib]
 path = "./src/lib.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
 ]
 
 [features]
-std = [dep:jolt-sdk:std]
+std = ["jolt-sdk/std"]
 
 [lib]
 path = "./src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ path = "./src/main.rs"
 
 [dependencies]
 jolt-sdk = { path = "./jolt-sdk" }
+clap = { version = "4.5.4", features = ["derive"] }
+eyre = "0.6.12"
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
 ]
 
 [features]
-std = []
+std = [dep:jolt-sdk:std]
 
 [lib]
 path = "./src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-pub use jolt_sdk;
+pub use jolt_sdk::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,125 @@
-fn main() {
-    println!("jolt");
+use std::{fs::{self, File}, io::Write};
+
+use clap::{Parser, Subcommand};
+use eyre::Result;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
 }
+
+#[derive(Subcommand)]
+enum Command {
+    /// Creates a new Jolt project with the specified name
+    New {
+        /// Project name
+        name: String,
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::New { name } => create_project(name),
+    }
+}
+
+fn create_project(name: String) {
+    create_folder_structure(&name).expect("could not create directory");
+    create_host_files(&name).expect("file creation failed");
+    create_guest_files(&name).expect("file creation failed");
+}
+
+fn create_folder_structure(name: &str) -> Result<()> {
+    fs::create_dir(name)?;
+    fs::create_dir(format!("{}/src", name))?;
+    fs::create_dir(format!("{}/guest", name))?;
+    fs::create_dir(format!("{}/guest/src", name))?;
+
+    Ok(())
+}
+
+fn create_host_files(name: &str) -> Result<()> {
+    let cargo_file_contents = HOST_CARGO_TEMPLATE.replace("{NAME}", name);
+    let mut cargo_file = File::create(format!("{}/Cargo.toml", name))?;
+    cargo_file.write(cargo_file_contents.as_bytes())?;
+
+    let mut main_file = File::create(format!("{}/src/main.rs", name))?;
+    main_file.write(HOST_MAIN.as_bytes())?;
+
+    Ok(())
+}
+
+fn create_guest_files(name: &str) -> Result<()> {
+    let mut cargo_file = File::create(format!("{}/guest/Cargo.toml", name))?;
+    cargo_file.write(GUEST_CARGO.as_bytes())?;
+
+    let mut lib_file = File::create(format!("{}/guest/src/lib.rs", name))?;
+    lib_file.write(GUEST_LIB.as_bytes())?;
+
+    Ok(())
+}
+
+const HOST_CARGO_TEMPLATE: &str = r#"
+[package]
+name = "{NAME}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+jolt = { git = "https://github.com/a16z/Lasso", branch = "jolt", features = ["std"] }
+guest = { path = "./guest" }
+
+hex = "0.4.3"
+sha3 = { version = "0.10.8", default-features = false }
+"#;
+
+const HOST_MAIN: &str = r#"
+pub fn main() {
+    let (prove_fib, verify_fib) = guest::build_fib();
+
+    let (output, proof) = prove_fib(50);
+    let is_valid = verify_fib(proof);
+
+    println!("output: {}", output);
+    println!("valid: {}", is_valid);
+}
+"#;
+
+const GUEST_CARGO: &str = r#"
+[package]
+name = "guest"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "guest"
+path = "./src/lib.rs"
+
+[features]
+guest = []
+
+[dependencies]
+jolt = { git = "https://github.com/a16z/Lasso", branch = "jolt" }
+"#;
+
+const GUEST_LIB: &str = r#"
+#![cfg_attr(feature = "guest", no_std)]
+#![no_main]
+
+#[jolt::provable]
+fn fib(n: u32) -> u128 {
+    let mut a: u128 = 0;
+    let mut b: u128 = 1;
+    let mut sum: u128;
+    for _ in 1..n {
+        sum = a + b;
+        a = b;
+        b = sum;
+    }
+
+    b
+}
+"#;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,11 @@ lto = "fat"
 [dependencies]
 jolt = { package = "jolt-sdk", git = "https://github.com/a16z/Lasso", branch = "jolt", features = ["std"] }
 guest = { path = "./guest" }
+
+[patch.crates-io]
+ark-ff = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64" }
+ark-ec = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64" }
+ark-serialize = { git = "https://github.com/a16z/arkworks-algebra", branch = "optimize/field-from-u64" }
 "#;
 
 const HOST_MAIN: &str = r#"pub fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,12 +84,14 @@ edition = "2021"
 [workspace]
 members = ["guest"]
 
+[profile.release]
+debug = 1
+codegen-units = 1
+lto = "fat"
+
 [dependencies]
 jolt = { git = "https://github.com/a16z/Lasso", branch = "jolt", features = ["std"] }
 guest = { path = "./guest" }
-
-hex = "0.4.3"
-sha3 = { version = "0.10.8", default-features = false }
 "#;
 
 const HOST_MAIN: &str = r#"

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ enum Command {
         /// Project name
         name: String,
     },
+    /// Installs the required RISC-V toolchain for Rust
     InstallToolchain,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,9 @@ name = "{NAME}"
 version = "0.1.0"
 edition = "2021"
 
+[workspace]
+members = ["guest"]
+
 [dependencies]
 jolt = { git = "https://github.com/a16z/Lasso", branch = "jolt", features = ["std"] }
 guest = { path = "./guest" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,15 @@ enum Command {
     New {
         /// Project name
         name: String,
-    }
+    },
+    InstallToolchain,
 }
 
 fn main() {
     let cli = Cli::parse();
     match cli.command {
         Command::New { name } => create_project(name),
+        Command::InstallToolchain => install_toolchain(),
     }
 }
 
@@ -30,6 +32,14 @@ fn create_project(name: String) {
     create_folder_structure(&name).expect("could not create directory");
     create_host_files(&name).expect("file creation failed");
     create_guest_files(&name).expect("file creation failed");
+}
+
+fn install_toolchain() {
+   std::process::Command::new("rustup")
+       .args(["target", "add", "riscv32i-unknown-none-elf"])
+       .output()
+       .expect("could not install toolchain");
+
 }
 
 fn create_folder_structure(name: &str) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("jolt");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,9 @@ fn create_folder_structure(name: &str) -> Result<()> {
 }
 
 fn create_host_files(name: &str) -> Result<()> {
+    let mut toolchain_file = File::create(format!("{}/rust-toolchain", name))?;
+    toolchain_file.write("nightly-2023-09-22".as_bytes())?;
+
     let cargo_file_contents = HOST_CARGO_TEMPLATE.replace("{NAME}", name);
     let mut cargo_file = File::create(format!("{}/Cargo.toml", name))?;
     cargo_file.write(cargo_file_contents.as_bytes())?;


### PR DESCRIPTION
To install run: `cargo install --git https://github.com/a16z/Lasso --branch jolt --force` (will only work after merge)

To install toolchain run: `jolt install-toolchain`

To create new project run `jolt new <NAME>` and a new directory will be created with the name <NAME> and a simple fibonacci example.

Note: we will need to update the branch in the toml file once we change the branch from jolt to master.

For some reason I have to import jolt_sdk directly rather than jolt or the no_std in the guest compilation is not respected. I'd like to fix this but am unsure how. If anyone has any ideas let me know.