### PR TITLE
optimize: 4x DensePolynomial::merge

### DIFF
--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -110,8 +110,10 @@ where
 
     #[tracing::instrument(skip_all, name = "InstructionPolynomials::batch")]
     fn batch(&self) -> Self::BatchedPolynomials {
+        let num = self.final_cts.len();
+        let len = self.final_cts[0].len();
         Self::BatchedPolynomials {
-            batched_final: DensePolynomial::merge(self.final_cts.iter()),
+            batched_final: DensePolynomial::merge(self.final_cts.par_iter(), num, len)
         }
     }
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -452,8 +452,10 @@ where
 
     #[tracing::instrument(skip_all, name = "ReadWriteMemory::batch")]
     fn batch(&self) -> Self::BatchedPolynomials {
+        let num = self.t_read.len() + self.t_write.len();
+        let len = self.t_write[0].len();
         let batched_t_read_write =
-            DensePolynomial::merge(self.t_read.iter().chain(self.t_write.iter()));
+            DensePolynomial::merge(self.t_read.par_iter().chain(self.t_write.par_iter()), num, len);
 
         Self::BatchedPolynomials {
             batched_t_read_write,

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -182,12 +182,16 @@ where
 
     #[tracing::instrument(skip_all, name = "RangeCheckPolynomials::batch")]
     fn batch(&self) -> Self::BatchedPolynomials {
+        let num = MEMORY_OPS_PER_INSTRUCTION * 4;
+        let len = self.read_cts_read_timestamp[0].len();
         DensePolynomial::merge(
             self.read_cts_read_timestamp
-                .iter()
-                .chain(self.read_cts_global_minus_read.iter())
-                .chain(self.final_cts_read_timestamp.iter())
-                .chain(self.final_cts_global_minus_read.iter()),
+                .par_iter()
+                .chain(self.read_cts_global_minus_read.par_iter())
+                .chain(self.final_cts_read_timestamp.par_iter())
+                .chain(self.final_cts_global_minus_read.par_iter()),
+            num,
+            len
         )
     }
 


### PR DESCRIPTION
Accelerate polynomial merging.

This is close to as fast as we'll get. Makes the interface a bit gross. Should likely remove the merging / batching steps entirely.