### PR TITLE
IO consistency constraints

### DIFF
--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -495,6 +495,7 @@ pub trait Jolt<F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize, co
             R1CSProof::<F, G>::compute_witness_commit(
                 32,
                 C,
+                trace_len, 
                 padded_trace_len,
                 inputs,
                 &preprocessing.generators,

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -495,7 +495,6 @@ pub trait Jolt<F: PrimeField, G: CurveGroup<ScalarField = F>, const C: usize, co
             R1CSProof::<F, G>::compute_witness_commit(
                 32,
                 C,
-                trace_len, 
                 padded_trace_len,
                 inputs,
                 &preprocessing.generators,

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -34,8 +34,8 @@ const STATE_LENGTH: usize = 1;
 #[derive(Debug, PartialEq, Eq, Hash)]
 enum InputType {
     Constant       = 0,
-    OutputState    = 1,
-    InputState     = 2,
+    InputState     = 1,
+    OutputState    = 2,
     ProgARW        = 3,
     ProgVRW        = 4,
     MemregARW      = 5,
@@ -51,8 +51,8 @@ enum InputType {
 
 const INPUT_SIZES: &[(InputType, usize)] = &[
     (InputType::Constant,        1), 
-    (InputType::OutputState,     STATE_LENGTH),
     (InputType::InputState,      STATE_LENGTH),
+    (InputType::OutputState,     STATE_LENGTH),
     (InputType::ProgARW,         1),
     (InputType::ProgVRW,         5),
     (InputType::MemregARW,       4),

--- a/jolt-core/src/r1cs/r1cs_shape.rs
+++ b/jolt-core/src/r1cs/r1cs_shape.rs
@@ -220,11 +220,10 @@ impl<F: PrimeField> R1CSShape<F> {
                 for &(_, col, val) in R {
                     if col == self.num_vars {
                         result.par_iter_mut().for_each(|x| *x += val);
-                    // } else if col == 0 { // PC_out
-                    //     let pc_start_idx = 1 * num_steps; // NOTE: Share the input PCs for output 
-                    //     result.par_iter_mut().enumerate().for_each(|(i, x)| {
-                    //         *x += mul_0_1_optimized(&val, &full_witness_vector[pc_start_idx+i+1]); // +1 as pc_out for step i is pc_in for step i+1 
-                    //     });
+                    } else if col == 1 { // pc_out variable index is 1 (pc_in is 0)
+                        result.par_iter_mut().enumerate().for_each(|(i, x)| {
+                            *x += mul_0_1_optimized(&val, &full_witness_vector[i+1]); // pc_out[i] = pc_in[i+1] = index i+1 in z
+                        });
                     } else {
                         let witness_offset = col * num_steps;
                         result.par_iter_mut().enumerate().for_each(|(i, x)| {

--- a/jolt-core/src/r1cs/r1cs_shape.rs
+++ b/jolt-core/src/r1cs/r1cs_shape.rs
@@ -192,8 +192,7 @@ impl<F: PrimeField> R1CSShape<F> {
     pub fn multiply_vec_uniform<P: IndexablePoly<F>>(
         &self,
         full_witness_vector: &P,
-        true_num_steps: usize,
-        num_steps: usize, // padded
+        num_steps: usize, // padded length
         A: &mut Vec<F>,
         B: &mut Vec<F>,
         C: &mut Vec<F>
@@ -263,19 +262,6 @@ impl<F: PrimeField> R1CSShape<F> {
                 )
             },
         );
-
-        // /* IO consistency, enforced by adding the following constraint for each step i: 
-        // A, B: empty 
-        // C: C[output of step i] - C[input of step i+1]
-        //  */
-        // let start_row_io_consistency = (self.num_cons-1) * num_steps; 
-        // C[start_row_io_consistency..start_row_io_consistency + true_num_steps - 1]
-        //     .par_iter_mut()
-        //     .enumerate()
-        //     .for_each(|(i, c)| {
-        //         *c += full_witness_vector[i] - full_witness_vector[num_steps+i+1];
-        //     }
-        // );
 
         Ok(())
     }

--- a/jolt-core/src/r1cs/r1cs_shape.rs
+++ b/jolt-core/src/r1cs/r1cs_shape.rs
@@ -260,18 +260,18 @@ impl<F: PrimeField> R1CSShape<F> {
             },
         );
 
-        /* IO consistency, enforced by adding the following constraint for each step i: 
-        A, B: empty 
-        C: C[output of step i] - C[input of step i+1]
-         */
-        let start_row_io_consistency = (self.num_cons-1) * num_steps; 
-        C[start_row_io_consistency..start_row_io_consistency + true_num_steps - 1]
-            .par_iter_mut()
-            .enumerate()
-            .for_each(|(i, c)| {
-                *c += full_witness_vector[i] - full_witness_vector[num_steps+i+1];
-            }
-        );
+        // /* IO consistency, enforced by adding the following constraint for each step i: 
+        // A, B: empty 
+        // C: C[output of step i] - C[input of step i+1]
+        //  */
+        // let start_row_io_consistency = (self.num_cons-1) * num_steps; 
+        // C[start_row_io_consistency..start_row_io_consistency + true_num_steps - 1]
+        //     .par_iter_mut()
+        //     .enumerate()
+        //     .for_each(|(i, c)| {
+        //         *c += full_witness_vector[i] - full_witness_vector[num_steps+i+1];
+        //     }
+        // );
 
         Ok(())
     }

--- a/jolt-core/src/r1cs/r1cs_shape.rs
+++ b/jolt-core/src/r1cs/r1cs_shape.rs
@@ -220,6 +220,11 @@ impl<F: PrimeField> R1CSShape<F> {
                 for &(_, col, val) in R {
                     if col == self.num_vars {
                         result.par_iter_mut().for_each(|x| *x += val);
+                    // } else if col == 0 { // PC_out
+                    //     let pc_start_idx = 1 * num_steps; // NOTE: Share the input PCs for output 
+                    //     result.par_iter_mut().enumerate().for_each(|(i, x)| {
+                    //         *x += mul_0_1_optimized(&val, &full_witness_vector[pc_start_idx+i+1]); // +1 as pc_out for step i is pc_in for step i+1 
+                    //     });
                     } else {
                         let witness_offset = col * num_steps;
                         result.par_iter_mut().enumerate().for_each(|(i, x)| {
@@ -260,18 +265,18 @@ impl<F: PrimeField> R1CSShape<F> {
             },
         );
 
-        /* IO consistency, enforced by adding the following constraint for each step i: 
-        A, B: empty 
-        C: C[output of step i] - C[input of step i+1]
-         */
-        let start_row_io_consistency = (self.num_cons-1) * num_steps; 
-        C[start_row_io_consistency..start_row_io_consistency + true_num_steps - 1]
-            .par_iter_mut()
-            .enumerate()
-            .for_each(|(i, c)| {
-                *c += full_witness_vector[i] - full_witness_vector[num_steps+i+1];
-            }
-        );
+        // /* IO consistency, enforced by adding the following constraint for each step i: 
+        // A, B: empty 
+        // C: C[output of step i] - C[input of step i+1]
+        //  */
+        // let start_row_io_consistency = (self.num_cons-1) * num_steps; 
+        // C[start_row_io_consistency..start_row_io_consistency + true_num_steps - 1]
+        //     .par_iter_mut()
+        //     .enumerate()
+        //     .for_each(|(i, c)| {
+        //         *c += full_witness_vector[i] - full_witness_vector[num_steps+i+1];
+        //     }
+        // );
 
         Ok(())
     }

--- a/jolt-core/src/r1cs/r1cs_shape.rs
+++ b/jolt-core/src/r1cs/r1cs_shape.rs
@@ -260,18 +260,18 @@ impl<F: PrimeField> R1CSShape<F> {
             },
         );
 
-        // /* IO consistency, enforced by adding the following constraint for each step i: 
-        // A, B: empty 
-        // C: C[output of step i] - C[input of step i+1]
-        //  */
-        // let start_row_io_consistency = (self.num_cons-1) * num_steps; 
-        // C[start_row_io_consistency..start_row_io_consistency + true_num_steps - 1]
-        //     .par_iter_mut()
-        //     .enumerate()
-        //     .for_each(|(i, c)| {
-        //         *c += full_witness_vector[i] - full_witness_vector[num_steps+i+1];
-        //     }
-        // );
+        /* IO consistency, enforced by adding the following constraint for each step i: 
+        A, B: empty 
+        C: C[output of step i] - C[input of step i+1]
+         */
+        let start_row_io_consistency = (self.num_cons-1) * num_steps; 
+        C[start_row_io_consistency..start_row_io_consistency + true_num_steps - 1]
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(i, c)| {
+                *c += full_witness_vector[i] - full_witness_vector[num_steps+i+1];
+            }
+        );
 
         Ok(())
     }

--- a/jolt-core/src/r1cs/r1cs_shape.rs
+++ b/jolt-core/src/r1cs/r1cs_shape.rs
@@ -192,7 +192,8 @@ impl<F: PrimeField> R1CSShape<F> {
     pub fn multiply_vec_uniform<P: IndexablePoly<F>>(
         &self,
         full_witness_vector: &P,
-        num_steps: usize,
+        true_num_steps: usize,
+        num_steps: usize, // padded
         A: &mut Vec<F>,
         B: &mut Vec<F>,
         C: &mut Vec<F>
@@ -258,6 +259,20 @@ impl<F: PrimeField> R1CSShape<F> {
                 )
             },
         );
+
+        /* IO consistency, enforced by adding the following constraint for each step i: 
+        A, B: empty 
+        C: C[output of step i] - C[input of step i+1]
+         */
+        let start_row_io_consistency = (self.num_cons-1) * num_steps; 
+        C[start_row_io_consistency..start_row_io_consistency + true_num_steps - 1]
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(i, c)| {
+                *c += full_witness_vector[i] - full_witness_vector[num_steps+i+1];
+            }
+        );
+
         Ok(())
     }
 

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -266,6 +266,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> R1CSProof<F, G> {
   pub fn compute_witness_commit(
       _W: usize, 
       _C: usize, 
+      true_trace_len: usize,
       padded_trace_len: usize, 
       inputs: R1CSInputs<F>,
       generators: &PedersenGenerators<G>,
@@ -274,7 +275,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> R1CSProof<F, G> {
       let _enter = span.enter();
       let mut jolt_shape = R1CSBuilder::default(); 
       R1CSBuilder::get_matrices(&mut jolt_shape); 
-      let key = UniformSpartanProof::<F,G>::setup_precommitted(&jolt_shape, padded_trace_len)?;
+      let key = UniformSpartanProof::<F,G>::setup_precommitted(&jolt_shape, true_trace_len, padded_trace_len)?;
       drop(_enter);
       drop(span);
 
@@ -378,7 +379,7 @@ impl<F: PrimeField> UniformShapeBuilder<F> for R1CSBuilder {
         A: constraints_F.0,
         B: constraints_F.1,
         C: constraints_F.2,
-        num_cons: jolt_shape.num_constraints,
+        num_cons: jolt_shape.num_constraints+1, // +1 for the IO consistency constraint 
         num_vars: jolt_shape.num_aux, // shouldn't include 1 or IO 
         num_io: jolt_shape.num_inputs,
     };

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -266,7 +266,6 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> R1CSProof<F, G> {
   pub fn compute_witness_commit(
       _W: usize, 
       _C: usize, 
-      true_trace_len: usize,
       padded_trace_len: usize, 
       inputs: R1CSInputs<F>,
       generators: &PedersenGenerators<G>,
@@ -275,7 +274,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> R1CSProof<F, G> {
       let _enter = span.enter();
       let mut jolt_shape = R1CSBuilder::default(); 
       R1CSBuilder::get_matrices(&mut jolt_shape); 
-      let key = UniformSpartanProof::<F,G>::setup_precommitted(&jolt_shape, true_trace_len, padded_trace_len)?;
+      let key = UniformSpartanProof::<F,G>::setup_precommitted(&jolt_shape, padded_trace_len)?;
       drop(_enter);
       drop(span);
 

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -25,7 +25,8 @@ fn synthesize_witnesses<F: PrimeField>(inputs: &R1CSInputs<F>, num_aux: usize) -
     } else {
         F::zero()
     };
-    (aux, pc_next, pc_cur)
+    // (aux, pc_next, pc_cur)
+    (aux, pc_cur, pc_next)
 }).collect();
   drop(_enter);
 

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -25,8 +25,7 @@ fn synthesize_witnesses<F: PrimeField>(inputs: &R1CSInputs<F>, num_aux: usize) -
     } else {
         F::zero()
     };
-    // (aux, pc_next, pc_cur)
-    (aux, pc_cur, pc_next)
+    (aux, pc_cur, F::zero())
 }).collect();
   drop(_enter);
 

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -385,26 +385,26 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
                 + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * constant_term_C;
 
 
-            // /* 4. Add IO consistency constraints, which ensure that (output_pc[step i] - input_pc[step i+1]) * input_pc[step i+1] = 0
-            //     For each step i in (0..NUM_STEPS-1):
-            //     A, B: 0 
-            //     C: output of i - input of i+1 ==> (index i, value 1), (index NUM_STEPS+i+1, value -1)
-            // */            
-            // let row_io_consistency = key.shape_single_step.num_cons-1; // this is considered the last constraint
-            // let r_sq_eq_rx_con = r_sq * eq_rx_con[row_io_consistency];
-            // RLC_evals[0..key.true_num_steps-1]
-            //     .par_iter_mut()
-            //     .enumerate()
-            //     .for_each(|(i, rlc)| {
-            //         *rlc += r_sq_eq_rx_con * eq_rx_ts[i];
-            //     });
+            /* 4. Add IO consistency constraints, which ensure that (output_pc[step i] - input_pc[step i+1]) * input_pc[step i+1] = 0
+                For each step i in (0..NUM_STEPS-1):
+                A, B: 0 
+                C: output of i - input of i+1 ==> (index i, value 1), (index NUM_STEPS+i+1, value -1)
+            */            
+            let row_io_consistency = key.shape_single_step.num_cons-1; // this is considered the last constraint
+            let r_sq_eq_rx_con = r_sq * eq_rx_con[row_io_consistency];
+            RLC_evals[0..key.true_num_steps-1]
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(i, rlc)| {
+                    *rlc += r_sq_eq_rx_con * eq_rx_ts[i];
+                });
 
-            // RLC_evals[key.num_steps+1..key.num_steps+key.true_num_steps]
-            //     .par_iter_mut()
-            //     .enumerate()
-            //     .for_each(|(i, rlc)| {
-            //         *rlc -= r_sq_eq_rx_con * eq_rx_ts[i];
-            //     });
+            RLC_evals[key.num_steps+1..key.num_steps+key.true_num_steps]
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(i, rlc)| {
+                    *rlc -= r_sq_eq_rx_con * eq_rx_ts[i];
+                });
 
             RLC_evals
         };
@@ -573,10 +573,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             (F::one() - inner_sumcheck_r[0]) * eval_W + inner_sumcheck_r[0] * eval_X
         };
 
-        // let (T_x, T_y) = rayon::join(
-        //         || EqPolynomial::new(r_x.to_vec()).evals(),
-        //         || EqPolynomial::new(inner_sumcheck_r.to_vec()).evals(),
-        //     );
+
 
         let num_steps_bits = key.num_steps.trailing_zeros();
         let (rx_con, rx_ts) =
@@ -619,7 +616,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
                     .collect()
             };
 
-        let evals = multi_evaluate_uniform(
+        let mut evals = multi_evaluate_uniform(
             &[
                 &key.shape_single_step.A,
                 &key.shape_single_step.B,
@@ -627,12 +624,16 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             ]
         );
 
-        // // Handle IO consistency  
-        // let start_row_io_consistency = (key.shape_single_step.num_cons-1) * key.num_steps; 
-        // evals[2] += (0..key.true_num_steps-1)
-        //     .into_par_iter()
-        //     .map(|i| T_x[start_row_io_consistency + i] * (T_y[i] - T_y[key.num_steps+i+1]))
-        //     .sum::<F>();
+        // Handle IO consistency  
+        let (T_x, T_y) = rayon::join(
+                || EqPolynomial::new(r_x.to_vec()).evals(),
+                || EqPolynomial::new(inner_sumcheck_r.to_vec()).evals(),
+            );
+        let start_row_io_consistency = (key.shape_single_step.num_cons-1) * key.num_steps; 
+        evals[2] += (0..key.true_num_steps-1)
+            .into_par_iter()
+            .map(|i| T_x[start_row_io_consistency + i] * (T_y[i] - T_y[key.num_steps+i+1]))
+            .sum::<F>();
 
         let left_expected = evals[0]
             + r_inner_sumcheck_RLC * evals[1]

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -385,26 +385,26 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
                 + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * constant_term_C;
 
 
-            /* 4. Add IO consistency constraints, which ensure that (output_pc[step i] - input_pc[step i+1]) * input_pc[step i+1] = 0
-                For each step i in (0..NUM_STEPS-1):
-                A, B: 0 
-                C: output of i - input of i+1 ==> (index i, value 1), (index NUM_STEPS+i+1, value -1)
-            */            
-            let row_io_consistency = key.shape_single_step.num_cons-1; // this is considered the last constraint
-            let r_sq_eq_rx_con = r_sq * eq_rx_con[row_io_consistency];
-            RLC_evals[0..key.true_num_steps-1]
-                .par_iter_mut()
-                .enumerate()
-                .for_each(|(i, rlc)| {
-                    *rlc += r_sq_eq_rx_con * eq_rx_ts[i];
-                });
+            // /* 4. Add IO consistency constraints, which ensure that (output_pc[step i] - input_pc[step i+1]) * input_pc[step i+1] = 0
+            //     For each step i in (0..NUM_STEPS-1):
+            //     A, B: 0 
+            //     C: output of i - input of i+1 ==> (index i, value 1), (index NUM_STEPS+i+1, value -1)
+            // */            
+            // let row_io_consistency = key.shape_single_step.num_cons-1; // this is considered the last constraint
+            // let r_sq_eq_rx_con = r_sq * eq_rx_con[row_io_consistency];
+            // RLC_evals[0..key.true_num_steps-1]
+            //     .par_iter_mut()
+            //     .enumerate()
+            //     .for_each(|(i, rlc)| {
+            //         *rlc += r_sq_eq_rx_con * eq_rx_ts[i];
+            //     });
 
-            RLC_evals[key.num_steps+1..key.num_steps+key.true_num_steps]
-                .par_iter_mut()
-                .enumerate()
-                .for_each(|(i, rlc)| {
-                    *rlc -= r_sq_eq_rx_con * eq_rx_ts[i];
-                });
+            // RLC_evals[key.num_steps+1..key.num_steps+key.true_num_steps]
+            //     .par_iter_mut()
+            //     .enumerate()
+            //     .for_each(|(i, rlc)| {
+            //         *rlc -= r_sq_eq_rx_con * eq_rx_ts[i];
+            //     });
 
             RLC_evals
         };
@@ -624,16 +624,16 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             ]
         );
 
-        // Handle IO consistency  
-        let (T_x, T_y) = rayon::join(
-                || EqPolynomial::new(r_x.to_vec()).evals(),
-                || EqPolynomial::new(inner_sumcheck_r.to_vec()).evals(),
-            );
-        let start_row_io_consistency = (key.shape_single_step.num_cons-1) * key.num_steps; 
-        evals[2] += (0..key.true_num_steps-1)
-            .into_par_iter()
-            .map(|i| T_x[start_row_io_consistency + i] * (T_y[i] - T_y[key.num_steps+i+1]))
-            .sum::<F>();
+        // // Handle IO consistency  
+        // let (T_x, T_y) = rayon::join(
+        //         || EqPolynomial::new(r_x.to_vec()).evals(),
+        //         || EqPolynomial::new(inner_sumcheck_r.to_vec()).evals(),
+        //     );
+        // let start_row_io_consistency = (key.shape_single_step.num_cons-1) * key.num_steps; 
+        // evals[2] += (0..key.true_num_steps-1)
+        //     .into_par_iter()
+        //     .map(|i| T_x[start_row_io_consistency + i] * (T_y[i] - T_y[key.num_steps+i+1]))
+        //     .sum::<F>();
 
         let left_expected = evals[0]
             + r_inner_sumcheck_RLC * evals[1]

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -25,7 +25,6 @@ pub struct UniformSpartanKey<F: PrimeField> {
     shape_single_step: R1CSShape<F>, // Single step shape
     num_cons_total: usize,           // Number of constraints
     num_vars_total: usize,           // Number of variables
-    true_num_steps: usize,           // Number of steps
     num_steps: usize,                // Padded number of steps
     vk_digest: F,                    // digest of the verifier's key
 }
@@ -160,7 +159,6 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
     #[tracing::instrument(skip_all, name = "UniformSpartanProof::setup_precommitted")]
     pub fn setup_precommitted<C: UniformShapeBuilder<F>>(
         circuit: &C,
-        true_num_steps: usize, 
         padded_num_steps: usize,
     ) -> Result<UniformSpartanKey<F>, SpartanError> {
         let shape_single_step = circuit.single_step_shape();
@@ -178,7 +176,6 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             shape_single_step,
             num_cons_total: pad_num_constraints,
             num_vars_total: pad_num_aux,
-            true_num_steps: true_num_steps, 
             num_steps: padded_num_steps,
             vk_digest,
         };
@@ -222,7 +219,6 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
 
         key.shape_single_step.multiply_vec_uniform(
             &segmented_padded_witness,
-            key.true_num_steps, 
             key.num_steps,
             &mut A_z,
             &mut B_z,

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -1,3 +1,4 @@
+use crate::jolt::subtable::eq;
 use crate::poly::hyrax::BatchedHyraxOpeningProof;
 use crate::poly::pedersen::PedersenGenerators;
 use crate::utils::compute_dotproduct_low_optimized;
@@ -24,7 +25,8 @@ pub struct UniformSpartanKey<F: PrimeField> {
     shape_single_step: R1CSShape<F>, // Single step shape
     num_cons_total: usize,           // Number of constraints
     num_vars_total: usize,           // Number of variables
-    num_steps: usize,                // Number of steps
+    true_num_steps: usize,           // Number of steps
+    num_steps: usize,                // Padded number of steps
     vk_digest: F,                    // digest of the verifier's key
 }
 
@@ -158,12 +160,13 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
     #[tracing::instrument(skip_all, name = "UniformSpartanProof::setup_precommitted")]
     pub fn setup_precommitted<C: UniformShapeBuilder<F>>(
         circuit: &C,
-        num_steps: usize,
+        true_num_steps: usize, 
+        padded_num_steps: usize,
     ) -> Result<UniformSpartanKey<F>, SpartanError> {
         let shape_single_step = circuit.single_step_shape();
 
-        let num_constraints_total = shape_single_step.num_cons * num_steps;
-        let num_aux_total = shape_single_step.num_vars * num_steps;
+        let num_constraints_total = shape_single_step.num_cons * padded_num_steps;
+        let num_aux_total = shape_single_step.num_vars * padded_num_steps;
 
         let pad_num_constraints = num_constraints_total.next_power_of_two();
         let pad_num_aux = num_aux_total.next_power_of_two();
@@ -175,7 +178,8 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             shape_single_step,
             num_cons_total: pad_num_constraints,
             num_vars_total: pad_num_aux,
-            num_steps,
+            true_num_steps: true_num_steps, 
+            num_steps: padded_num_steps,
             vk_digest,
         };
         Ok(key)
@@ -218,6 +222,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
 
         key.shape_single_step.multiply_vec_uniform(
             &segmented_padded_witness,
+            key.true_num_steps, 
             key.num_steps,
             &mut A_z,
             &mut B_z,
@@ -293,7 +298,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             // With uniformity, each entry of the RLC of A, B, C can be expressed using
             // the RLC of the small_A, small_B, small_C matrices.
 
-            // 1. Evaluate \tilde smallM(r_x, y) for all y
+            // 1. Evaluate \tilde smallM(r_x, y) for all y. Here, \tilde smallM(r_x, y) = \sum_{x} eq(r_x, x) * smallM(x, y)
             let compute_eval_table_sparse_single = |small_M: &Vec<(usize, usize, F)>| -> Vec<F> {
                 let mut small_M_evals = vec![F::zero(); key.shape_single_step.num_vars + 1];
                 for (row, col, val) in small_M.iter() {
@@ -311,7 +316,7 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
                     )
                 },
             );
-
+            
             let span = tracing::span!(tracing::Level::TRACE, "poly_ABC_small_RLC_evals");
             let _enter = span.enter();
             let r_sq = r_inner_sumcheck_RLC * r_inner_sumcheck_RLC;
@@ -325,7 +330,9 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
                 .collect::<Vec<F>>();
             drop(_enter);
 
-            // 2. Handles all entries but the last one with the constant 1 variable
+            // 2. Obtains the MLE evaluation for each variable y in the full matrix. 
+            // We first handle all entries but the last one with the constant 1 variable. 
+            // Each entry is just the small_RLC_evals for the corresponding variable multiplied with eq_rx_tx[timestamp of variable]
             let other_span = tracing::span!(tracing::Level::TRACE, "poly_ABC_wait_alloc_complete");
             let _other_enter = other_span.enter();
             let mut RLC_evals = unsafe_allocate_zero_vec(poly_ABC_len);
@@ -347,7 +354,8 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
                 });
             drop(_enter);
 
-            // 3. Handles the constant 1 variable
+            // 3. Handles the constant 1 variable, which was left over from the previous step. 
+            // The difference is that there is only one constnat variable, so it takes in all of eq_rx_ts (hence, eq_sum below). 
             let span = tracing::span!(tracing::Level::TRACE, "poly_ABC_constant");
             let _enter = span.enter();
             let eq_sum = eq_rx_ts.par_iter().sum::<F>();
@@ -375,6 +383,28 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             RLC_evals[key.num_vars_total] = constant_term_A
                 + r_inner_sumcheck_RLC * constant_term_B
                 + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * constant_term_C;
+
+
+            /* 4. Add IO consistency constraints, which ensure that (output_pc[step i] - input_pc[step i+1]) * input_pc[step i+1] = 0
+                For each step i in (0..NUM_STEPS-1):
+                A, B: 0 
+                C: output of i - input of i+1 ==> (index i, value 1), (index NUM_STEPS+i+1, value -1)
+            */            
+            let row_io_consistency = key.shape_single_step.num_cons-1; // this is considered the last constraint
+            let r_sq_eq_rx_con = r_sq * eq_rx_con[row_io_consistency];
+            RLC_evals[0..key.true_num_steps-1]
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(i, rlc)| {
+                    *rlc += r_sq_eq_rx_con * eq_rx_ts[i];
+                });
+
+            RLC_evals[key.num_steps+1..key.num_steps+key.true_num_steps]
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(i, rlc)| {
+                    *rlc -= r_sq_eq_rx_con * eq_rx_ts[i];
+                });
 
             RLC_evals
         };
@@ -543,6 +573,11 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             (F::one() - inner_sumcheck_r[0]) * eval_W + inner_sumcheck_r[0] * eval_X
         };
 
+        let (T_x, T_y) = rayon::join(
+                || EqPolynomial::new(r_x.to_vec()).evals(),
+                || EqPolynomial::new(inner_sumcheck_r.to_vec()).evals(),
+            );
+
         // compute evaluations of R1CS matrices
         let multi_evaluate_uniform =
             |M_vec: &[&[(usize, usize, F)]], r_x: &[F], r_y: &[F], num_steps: usize| -> Vec<F> {
@@ -569,18 +604,13 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
                             .sum()
                     };
 
-                let (T_x, T_y) = rayon::join(
-                    || EqPolynomial::new(r_x.to_vec()).evals(),
-                    || EqPolynomial::new(r_y.to_vec()).evals(),
-                );
-
                 (0..M_vec.len())
                     .into_par_iter()
                     .map(|i| evaluate_with_table_uniform(M_vec[i], &T_x, &T_y, num_steps))
                     .collect()
             };
 
-        let evals = multi_evaluate_uniform(
+        let mut evals = multi_evaluate_uniform(
             &[
                 &key.shape_single_step.A,
                 &key.shape_single_step.B,
@@ -590,6 +620,13 @@ impl<F: PrimeField, G: CurveGroup<ScalarField = F>> UniformSpartanProof<F, G> {
             &inner_sumcheck_r,
             key.num_steps,
         );
+
+        // Handle IO consistency  
+        let start_row_io_consistency = (key.shape_single_step.num_cons-1) * key.num_steps; 
+        evals[2] += (0..key.true_num_steps-1)
+            .into_par_iter()
+            .map(|i| T_x[start_row_io_consistency + i] * (T_y[i] - T_y[key.num_steps+i+1]))
+            .sum::<F>();
 
         let left_expected = evals[0]
             + r_inner_sumcheck_RLC * evals[1]


### PR DESCRIPTION
Adds a constraint per step that checks that the output PC of step i is the input PC to step i+1. This is only enforced for the true (non padded) steps of the trace, which is passed as a new variable. 

This requires modifying the r1cs matrix-vector multiplication and the MLE evaluations for both the prover and verifier. 

(There are optimizations that improve overall performance and also avoid this, but require changing the trace.)

