### PR TITLE
refactor: fiat shamir additions

### DIFF
--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -84,6 +84,24 @@ pub struct InstructionCommitment<G: CurveGroup> {
     pub final_commitment: Vec<HyraxCommitment<64, G>>,
 }
 
+
+impl<G: CurveGroup> AppendToTranscript<G> for InstructionCommitment<G> {
+    fn append_to_transcript<T: ProofTranscript<G>>(
+        &self,
+        label: &'static [u8],
+        transcript: &mut T,
+    ) {
+        transcript.append_message(label, b"InstructionCommitment_begin");
+        for commitment in &self.trace_commitment {
+            commitment.append_to_transcript(b"trace_commitment", transcript);
+        }
+        for commitment in &self.final_commitment{
+            commitment.append_to_transcript(b"final_commitment", transcript);
+        }
+        transcript.append_message(label, b"InstructionCommitment_end");
+    }
+}
+
 // TODO: macro?
 impl<F, G> StructuredCommitment<G> for InstructionPolynomials<F, G>
 where

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     utils::{errors::ProofVerifyError, math::Math, mul_0_1_optimized, transcript::ProofTranscript},
 };
+use crate::utils::transcript::AppendToTranscript;
 
 use super::read_write_memory::MemoryCommitment;
 
@@ -169,6 +170,21 @@ where
 pub struct RangeCheckCommitment<G: CurveGroup> {
     pub(super) commitments: Vec<HyraxCommitment<NUM_R1CS_POLYS, G>>,
 }
+
+impl<G: CurveGroup> AppendToTranscript<G> for RangeCheckCommitment<G> {
+    fn append_to_transcript<T: ProofTranscript<G>>(
+        &self,
+        label: &'static [u8],
+        transcript: &mut T,
+    ) {
+        transcript.append_message(label, b"RangeCheckCommitment_begin");
+        for commitment in &self.commitments {
+            commitment.append_to_transcript(b"range", transcript);
+        }
+        transcript.append_message(label, b"RangeCheckCommitment_end");
+    }
+}
+
 
 impl<F, G> StructuredCommitment<G> for RangeCheckPolynomials<F, G>
 where

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -299,24 +299,29 @@ pub struct R1CSCommitment<G: CurveGroup> {
     circuit_flags: Vec<HyraxCommitment<NUM_R1CS_POLYS, G>>,
 }
 
-impl<G: CurveGroup> R1CSCommitment<G> {
-    #[tracing::instrument(skip_all, name = "R1CSCommitment::append_to_transcript")]
-    pub fn append_to_transcript(&self, transcript: &mut Transcript) {
-        self.io
-            .iter()
-            .for_each(|comm| comm.append_to_transcript(b"io", transcript));
-        self.aux
-            .iter()
-            .for_each(|comm| comm.append_to_transcript(b"aux", transcript));
-        self.chunks_x
-            .iter()
-            .for_each(|comm| comm.append_to_transcript(b"chunk_x", transcript));
-        self.chunks_y
-            .iter()
-            .for_each(|comm| comm.append_to_transcript(b"chunk_y", transcript));
-        self.circuit_flags
-            .iter()
-            .for_each(|comm| comm.append_to_transcript(b"circuit_flags", transcript));
+impl<G: CurveGroup> AppendToTranscript<G> for R1CSCommitment<G> {
+    fn append_to_transcript<T: ProofTranscript<G>>(
+        &self,
+        label: &'static [u8],
+        transcript: &mut T,
+    ) {
+        transcript.append_message(label, b"R1CSCommitment_begin");
+        for commitment in &self.io {
+            commitment.append_to_transcript(b"io", transcript);
+        }
+        for commitment in &self.aux {
+            commitment.append_to_transcript(b"aux", transcript);
+        }
+        for commitment in &self.chunks_x {
+            commitment.append_to_transcript(b"chunks_x", transcript);
+        }
+        for commitment in &self.chunks_y {
+            commitment.append_to_transcript(b"chunks_y", transcript);
+        }
+        for commitment in &self.circuit_flags {
+            commitment.append_to_transcript(b"circuit_flags", transcript);
+        }
+        transcript.append_message(label, b"R1CSCommitment_end");
     }
 }
 


### PR DESCRIPTION
Fiat shamirs all the commitments directly after creation.

At some point we should refactor the `AppendToTranscript` trait to reduce the number of labels hashed to make verifier cheaper + reduce implementation complexity. Definitely not a bottleneck for now.